### PR TITLE
feat: add bundled rclone binary to child process $PATH

### DIFF
--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -60,6 +60,7 @@ async function execPromise (cmd: string, site: Site, env: { [key: string]: strin
 				env: {
 					...process.env,
 					...env,
+					PATH: `${bins.binDir}:${process.env.PATH}`,
 				},
 				cwd: formatHomePath(site.path),
 			},

--- a/src/main/getOSBins.ts
+++ b/src/main/getOSBins.ts
@@ -1,12 +1,16 @@
 import fs from 'fs-extra';
 import path from 'path';
 
-interface Bins {
+interface BinPaths {
+	// Path to the restic binary
 	restic: string;
+	// Path to the rclone binary
 	rclone: string;
+	// Path to the directory where binaries are stored. This is useful for adding the above binaries to a system's path
+	binDir: string;
 }
 
-export default function (): Bins {
+export default function (): BinPaths {
 	let resticBinName;
 	let rcloneBinName;
 
@@ -36,6 +40,7 @@ export default function (): Bins {
 	const bins = {
 		restic: path.join(binDirPath, resticBinName),
 		rclone: path.join(binDirPath, rcloneBinName),
+		binDir: binDirPath,
 	};
 
 	if (!fs.existsSync(bins.restic)) {


### PR DESCRIPTION
### Summary

`restic` was not able to find the bundled `rclone` binary properly. This would cause backups to fail if `rclone` wasn't already on a user's `$PATH`.