### PR TITLE
feat: switch restore flow to restore to /tmp directory first

### DIFF
--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -15,6 +15,7 @@ interface RestoreFromBackupOptions {
 	provider: Providers;
 	encryptionPassword: string;
 	snapshotID: string;
+	restoreDir: string;
 }
 
 const bins = getOSBins();
@@ -140,7 +141,7 @@ export async function listSnapshots (site: Site, provider: Providers): Promise<[
 	const { localBackupRepoID } = site;
 
 	if (!localBackupRepoID) {
-		throw new Error('Could not list snapshots since to repo was found on the given provider');
+		throw new Error('Could not list snapshots since no repo was found on the given provider');
 	}
 
 	try {
@@ -275,13 +276,13 @@ Fatal: wrong password or no key found
  * @param options
  */
 export async function restoreBackup (options: RestoreFromBackupOptions) {
-	const { site, provider, encryptionPassword, snapshotID } = options;
+	const { site, provider, encryptionPassword, snapshotID, restoreDir } = options;
 	const { localBackupRepoID } = getSiteDataFromDisk(site.id);
 
 	const flags = [
 		'--json',
 		`--password-command "echo \'${encryptionPassword}\'"`,
-		`--target .`,
+		`--target ${restoreDir}`,
 		/**
 		 * @todo do not add this flag if restoring a backup to a brand new site within Local
 		 */


### PR DESCRIPTION
## Summary 

This PR switches the logic for restoring a backup so that a backup is first restored to a tmp directory, and then copied over to the site directory.

## Technical

- Renames and reorders the states for restoreMachine in `restoreService.ts`
- Adds `restoreDir` to `RestoreFromBackupOptions` in `cli.ts` and allows the restore command to access the tmp directory created in the restore service.
- Uses copySync instead of moveSync, and uses emptyDirSync in a few places for extra cleanup.