### PR TITLE
fix: add separate updateActiveSite thunk to fix series of dispatches order issue

### DIFF
--- a/src/renderer/components/siteinfotools/SiteInfoToolsSection.tsx
+++ b/src/renderer/components/siteinfotools/SiteInfoToolsSection.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Site } from '@getflywheel/local';
-import updateActiveSiteAndDataSources from '../updateActiveSiteAndDataSources';
+import useUpdateActiveSiteAndDataSources from '../useUpdateActiveSiteAndDataSources';
 import { useStoreSelector } from '../../store/store';
 import styles from './SiteInfoToolsSection.scss';
 import { ToolsHeader } from '../siteinfotools/ToolsHeader';
@@ -10,7 +10,7 @@ interface Props {
 }
 
 const SiteInfoToolsSection = ({ site }: Props) => {
-	updateActiveSiteAndDataSources(site.id);
+	useUpdateActiveSiteAndDataSources(site.id);
 
 	const { isLoadingEnabledProviders } = useStoreSelector((state) => state.providers);
 	const { snapshots } = useStoreSelector((state) => state.activeSite);

--- a/src/renderer/components/useUpdateActiveSiteAndDataSources.ts
+++ b/src/renderer/components/useUpdateActiveSiteAndDataSources.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { store, actions } from '../store/store';
 
-const updateActiveSiteAndDataSources = (siteID: string): void => useEffect(() => {
+const useUpdateActiveSiteAndDataSources = (siteID: string): void => useEffect(() => {
 	store.dispatch(actions.updateActiveSiteAndDataSources(siteID));
 
 	return () => {
@@ -9,4 +9,4 @@ const updateActiveSiteAndDataSources = (siteID: string): void => useEffect(() =>
 	};
 }, [siteID]);
 
-export default updateActiveSiteAndDataSources;
+export default useUpdateActiveSiteAndDataSources;

--- a/src/renderer/store/activeSiteSlice.ts
+++ b/src/renderer/store/activeSiteSlice.ts
@@ -4,8 +4,8 @@ import {
 } from '@reduxjs/toolkit';
 import { BackupSnapshot } from '../../types';
 import {
-	getSnapshotForActiveSiteProviderHub,
-	updateActiveSiteAndDataSources,
+	getSnapshotsForActiveSiteProviderHub,
+	updateActiveSite,
 } from './thunks';
 
 /**
@@ -23,20 +23,22 @@ export const activeSiteSlice = createSlice({
 		},
 	},
 	extraReducers: (builder) => {
-		builder.addCase(getSnapshotForActiveSiteProviderHub.fulfilled, (state, { payload }) => {
+		builder.addCase(getSnapshotsForActiveSiteProviderHub.fulfilled, (state, { payload }) => {
 			state.snapshots = payload;
 		});
-		builder.addCase(getSnapshotForActiveSiteProviderHub.pending, (state, { payload }) => {
+		builder.addCase(getSnapshotsForActiveSiteProviderHub.pending, (state, { payload }) => {
 			// todo - crum: handle pending
 		});
-		builder.addCase(getSnapshotForActiveSiteProviderHub.rejected, (_, action) => {
+		builder.addCase(getSnapshotsForActiveSiteProviderHub.rejected, (_, action) => {
 			// todo - crum: handle error
 			console.log('...rejected:', action.error);
 		});
-		builder.addCase(updateActiveSiteAndDataSources.fulfilled, (state, { payload }) => {
+		builder.addCase(updateActiveSite.fulfilled, (state, { payload }) => {
 			state.id = payload;
+
+			console.log('updateActiveSite.fulfilled: ', payload);
 		});
-		builder.addCase(updateActiveSiteAndDataSources.rejected, (_, action) => {
+		builder.addCase(updateActiveSite.rejected, (_, action) => {
 			// todo - crum: handle error
 			console.log('...rejected:', action.error);
 		});


### PR DESCRIPTION
## Summary

Thunk dispatch of `updateActiveSiteAndDataSources` calls a series of other thunks that need it to return its result before actually being used (so state if `null`). This fix adds an additional `updateActiveSite` thunk that's called within the series and resolves and is saved to the store before the next dispatch takes place.

## Technical

* The `updateActiveSiteAndDataSources` thunk now acts as a wrapper or "saga" that chains together a sequence of other thunks before ultimately resolving. Unlike before where its result is then handled in a builder case resolver within the `activeSiteSlice`, the result is now unhandled and it is the first of the chained dispatches `updateActiveSite` that now has the  builder case resolver on it that saves it to the store state.
* Cleaned up some of the other thunk returns and explicitly setting their types (e.g. `as BackupSnapshot[]`)
* Renamed hook `updateActiveSiteAndDataSources` to `useUpdateActiveSiteAndDataSources` to better differentiate it and follow common naming convention of the `use` prefix to better indicate to engineers that it's a hook and has a lifecycle