### PR TITLE
fix: WordPress core needs both of these to be included!

### DIFF
--- a/resources/default-ignore-file
+++ b/resources/default-ignore-file
@@ -19,10 +19,6 @@
 
 **/.git
 
-**/node_modules
-
-**/vendor
-
 **/cache
 
 wp-content/upgrade


### PR DESCRIPTION
WordPress includes many files in the vendor directory, and themes often include files directly from node_modules. 

One example: http://localhost:10042/wp-includes/js/dist/vendor/wp-polyfill.min.js?ver=7.4.4

We need both of these or sites will not restore properly.