### PR TITLE
feat: scope backups to a LocalBackups directory

### DIFF
--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -51,11 +51,22 @@ const makeRepoFlag = (provider: Providers, localBackupRepoID: string) => {
 	if (!localBackupRepoID) {
 		throw new Error('No repo id found for this site');
 	}
+
+	let fullRemotePath: string;
+
+	switch (provider) {
+		case Providers.Drive:
+			fullRemotePath = `LocalBackups/${localBackupRepoID}`;
+			break;
+		default:
+			fullRemotePath = localBackupRepoID;
+	}
+
 	/**
 	 * Note the double colon. This is because we are combining the restic syntax to use rclone as a backend
-	 * along with the rlcone :backend: syntax.
+	 * along with the rclone :backend: syntax.
 	 */
-	return `--repo rclone::${provider}:${localBackupRepoID}`;
+	return `--repo rclone::${provider}:${fullRemotePath}`;
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR introduces a small change to the restic/rclone API that modifies the Backup path so that backups for Google Drive are created in the /LocalBackups directory.

Additional testing of Dropbox proved out that Dropbox automatically creates a directory for Local Backups under /Apps/Local Backups, so no change was made for Dropbox.

## Technical

I uncovered a bug with the config data Hub was returning for Dropbox, causing backups to fail if Dropbox was selected as a provider. I pushed a commit to my existing Hub branch with the fix here:
- https://github.com/getflywheel/local-hub/pull/149/commits/95a4fd6e248f67535799d8aa0f805c5b794a5c42

Also pushed a UI change to Hub to accurately reflect the file paths that backups will be stored at now:
- https://github.com/getflywheel/local-hub/pull/149/commits/55171fd540aea83f3798643a6383572ba2309bc4

