### PR TITLE
fix: remove double quotes from password

### DIFF
--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -155,7 +155,7 @@ async function execPromiseWithRcloneContext (opts: { cmd: string; site: Site; pr
 		 * Define a command that restic can use to get the repository password dynamically. It's useful to set here as opposed to command line flag
 		 * since this only lives inside the scope of the spawned shell which should gaurd against the password getting dumped to a log file
 		 */
-		['RESTIC_PASSWORD']: `\"${encryptionPassword}\"`,
+		['RESTIC_PASSWORD']: encryptionPassword,
 	});
 }
 


### PR DESCRIPTION
## Problem 

We were adding double quotes to the `restic` password during `execPromiseWithRcloneContext` execution. This caused issues when trying to restore a site from backup manually using the password displayed on Hub.

## Solution

Remove the quotes.

Presumably, the quotes were added to avoid issues with special characters. But Hub sets the password as an alpha-numeric string, so I don't think we need to worry about that.

**NOTE: This is technically changing the password, so interacting with previous backups won't work once this PR is merged**