### PR TITLE
chore: update cloud backups url

### DIFF
--- a/src/renderer/helpers/launchBrowser.ts
+++ b/src/renderer/helpers/launchBrowser.ts
@@ -11,4 +11,4 @@ export const launchBrowser = (url: string) => ipcAsync(
 	url,
 );
 
-export const launchBrowserToHubBackups = () => launchBrowser(`${URLS.LOCAL_HUB}/addons/backups`);
+export const launchBrowserToHubBackups = () => launchBrowser(`${URLS.LOCAL_HUB}/addons/cloud-backups`);


### PR DESCRIPTION
## Summary
- Updates the Hub URL to use the new /accounts/cloud-backups url 
- Part of this ticket: https://wpengine.atlassian.net/browse/LOC-2832