### PR TITLE
fix: Replace Local Beta with LOCALB~1.

### DIFF
--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -69,8 +69,8 @@ const makeRepoFlag = (provider: Providers, localBackupRepoID: string, site) => {
 		 *  to the rclone binary from our current working directory (the site).
 		 */
 		const relativeRCLONEPath = path.relative(formatHomePath(site.path), bins.rclone)
-			.replace(/\\/g,"/") // Convert backslashes to forward which restic expects.
-			.replace(/\s/g, `\ `); // Convert spaces to escaped spaces.
+			.replace(/\\/g,'/') // Convert backslashes to forward which restic expects.
+			.replace('Local Beta', 'LOCALB~1'); // Use weird Windows specific format to avoid spaces in our command.
 
 		return `--repo rclone::${provider}:${fullRemotePath} -o rclone.program="${relativeRCLONEPath}"`;
 	}


### PR DESCRIPTION
I tried every single combination of escaping sequences possible, but no matter what the space just broke restic. Windows has this old format spaceless file name format, where ` LOCALB~1.` will resolve to `Local Beta`. 

So lets use that!