### PR TITLE
feat: fix site cloning carrying over localBackupRepoID from base site

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@getflywheel/local-addon-backups",
   "productName": "Cloud Backups",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": "Local Team",
   "keywords": [
     "local-addon"

--- a/src/main/services/cloneFromBackupService.ts
+++ b/src/main/services/cloneFromBackupService.ts
@@ -104,6 +104,7 @@ const setupDestinationSite = async (context: BackupMachineContext) => {
 	dupSite.id = dupID;
 	dupSite.name = newSiteName;
 
+	// get rid of the origin site's repo id reference to ensure the new clone has it's own repo created
 	delete dupSite.localBackupRepoID;
 
 	// todo - tyler: setup site status as part of site creation to resolve `status.indexof` issue

--- a/src/main/services/cloneFromBackupService.ts
+++ b/src/main/services/cloneFromBackupService.ts
@@ -97,12 +97,15 @@ const setupDestinationSite = async (context: BackupMachineContext) => {
 	}
 
 	const dupID = shortid.generate();
-	const dupSite = new Local.Site(baseSite);
+	const dupSite: Site = new Local.Site(baseSite);
 
 	const localSitesDir = path.dirname(baseSite.path);
 
 	dupSite.id = dupID;
 	dupSite.name = newSiteName;
+
+	delete dupSite.localBackupRepoID;
+
 	// todo - tyler: setup site status as part of site creation to resolve `status.indexof` issue
 
 	dupSite.domain = `${formattedSiteName}.local`;

--- a/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
+++ b/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
@@ -131,21 +131,21 @@ const renderCellMoreMenu = (snapshot: BackupSnapshot, site: Site, provider: HubP
 						),
 					),
 			});
-			// items.push({
-			// 	color: 'none',
-			// 	content: renderTextButton('Clone site from this backup', () => store.getState().director.backupIsRunning),
-			// 	onClick: store.getState().director.backupIsRunning
-			// 		? () => undefined
-			// 		: () => createModal(
-			// 			() => (
-			// 				<BackupCloneContents
-			// 					site={site}
-			// 					snapshot={snapshot}
-			// 					provider={provider}
-			// 				/>
-			// 			),
-			// 		),
-			// });
+			items.push({
+				color: 'none',
+				content: renderTextButton('Clone site from this backup', () => store.getState().director.backupIsRunning),
+				onClick: store.getState().director.backupIsRunning
+					? () => undefined
+					: () => createModal(
+						() => (
+							<BackupCloneContents
+								site={site}
+								snapshot={snapshot}
+								provider={provider}
+							/>
+						),
+					),
+			});
 	}
 
 	if (!items.length) {


### PR DESCRIPTION
## Summary

When cloning the site, we were copying the "localBackupRepoID" into the new clone's sites.json information. This kept the new clone tied to all the backups for the old site.

Super easy fix, just took a bit to track down!

Also uncommented the "clone site" button in the dropdown menu.