### PR TITLE
fix(LOC-2878): show in-progress and failed snapshot row only for the provider originating the call

### DIFF
--- a/src/renderer/store/directorSlice.ts
+++ b/src/renderer/store/directorSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import type { BackupSnapshot } from '../../types';
+import type { BackupSnapshot, HubProviderRecord } from '../../types';
 import { backupSite, cloneSite, restoreSite } from './thunks';
 
 /**
@@ -13,6 +13,8 @@ export const directorSlice = createSlice({
 		backupInMode: null as 'backup' | 'restore' | 'clone' | null,
 		/** whether backups is currently running (limited to 1) **/
 		backupIsRunning: false as boolean,
+		/** the provider being backed up to **/
+		backupProviderId: null as HubProviderRecord['id'] | null,
 		/** the site id for the currently running backup **/
 		backupSiteId: null as string | null,
 		/** a placeholder for the snapshot so it can be shown in the UI as either in-progress or having failed **/
@@ -23,6 +25,7 @@ export const directorSlice = createSlice({
 			// clear backup details thus signaling that there is no active or pending backup
 			state.backupInMode = null;
 			state.backupIsRunning = false;
+			state.backupProviderId = null;
 			state.backupSiteId = null;
 			state.backupSnapshotPlaceholder = null;
 		},
@@ -32,6 +35,7 @@ export const directorSlice = createSlice({
 			// clear backup details thus signaling that there is no active or pending backup
 			state.backupInMode = null;
 			state.backupIsRunning = false;
+			state.backupProviderId = null;
 			state.backupSiteId = null;
 			state.backupSnapshotPlaceholder = null;
 		});
@@ -39,6 +43,7 @@ export const directorSlice = createSlice({
 			// signal in-progress "running" state
 			state.backupInMode = 'backup';
 			state.backupIsRunning = true;
+			state.backupProviderId = meta.arg.providerId;
 			state.backupSiteId = meta.arg.siteId;
 			state.backupSnapshotPlaceholder = {
 				configObject: {
@@ -65,35 +70,41 @@ export const directorSlice = createSlice({
 			// clear backup details thus signaling that there is no active or pending backup
 			state.backupInMode = null;
 			state.backupIsRunning = false;
+			state.backupProviderId = null;
 			state.backupSiteId = null;
 		});
 		builder.addCase(cloneSite.pending, (state, { meta }) => {
 			// signal in-progress "running" state
 			state.backupInMode = 'clone';
 			state.backupIsRunning = true;
+			state.backupProviderId = null;
 			state.backupSiteId = meta.arg.siteId;
 		});
 		builder.addCase(cloneSite.rejected, (state) => {
 			// signal stalled by keeping other state but toggling running state
 			state.backupInMode = null;
 			state.backupIsRunning = false;
+			state.backupProviderId = null;
 		});
 		builder.addCase(restoreSite.fulfilled, (state) => {
 			// clear backup details thus signaling that there is no active or pending backup
 			state.backupInMode = null;
 			state.backupIsRunning = false;
+			state.backupProviderId = null;
 			state.backupSiteId = null;
 		});
 		builder.addCase(restoreSite.pending, (state, { meta }) => {
 			// signal in-progress "running" state
 			state.backupInMode = 'restore';
 			state.backupIsRunning = true;
+			state.backupProviderId = null;
 			state.backupSiteId = meta.arg.siteId;
 		});
 		builder.addCase(restoreSite.rejected, (state) => {
 			// signal stalled by keeping other state but toggling running state
 			state.backupInMode = null;
 			state.backupIsRunning = false;
+			state.backupProviderId = null;
 		});
 	},
 });

--- a/src/renderer/store/snapshotsSlice.ts
+++ b/src/renderer/store/snapshotsSlice.ts
@@ -3,6 +3,7 @@ import type { EntityState } from '@reduxjs/toolkit';
 import type { BackupSnapshot, PaginationInfo } from '../../types';
 import { clearSnapshotsForSite, getSnapshotsForActiveSiteProviderHub } from './thunks';
 import type { AppState } from './store';
+import { selectors } from './selectors';
 
 type SitePaging = {
 	hasLoadingError: boolean;
@@ -146,15 +147,24 @@ export const selectSnapshotsForActiveSitePlusExtra = createSelector(
 		(state: AppState) => state.director,
 		selectActiveSiteSnapshots,
 		(state: AppState) => state.snapshots.pagingBySite,
+		selectors.selectActiveProvider,
 	],
-	(activeSite, director, selectActiveSiteSnapshots, pagingBySite) => {
+	(
+		activeSite,
+		director,
+		selectActiveSiteSnapshots,
+		pagingBySite,
+		activeSiteProvider,
+	) => {
 		const paging = pagingBySite[activeSite.id];
 
 		return [
 			// prepend placeholder snapshot only if the backup is for the active site
-			...(director.backupSnapshotPlaceholder && activeSite.id === director.backupSiteId
-				? [director.backupSnapshotPlaceholder]
-				: []
+			...(director.backupSnapshotPlaceholder
+				&& activeSite.id === director.backupSiteId
+				&& activeSiteProvider?.id === director.backupProviderId
+					? [director.backupSnapshotPlaceholder]
+					: []
 			),
 			...selectActiveSiteSnapshots ?? [],
 			...(paging && paging.hasMore && !paging.isLoading


### PR DESCRIPTION
## Summary

Both in-progress and failed snapshots should only have a row representing it in the table for the provider that is attempting to backup and/or has failed. When switching providers, it should not be included in list of backup snapshots.

## Technical

* track and check which provider requested a backup
* only show in-progress and failed backups in table if the active provider is the one that requested it
* the in-progress and failed rows are one-in-the-same so fixing one fixes the other

## Screenshot

### Before (in-progress example)

https://user-images.githubusercontent.com/41925404/124632332-dc018c80-de49-11eb-86fd-670310e0a60a.mov


### After (failed example)
https://user-images.githubusercontent.com/41925404/124178700-624b5680-da77-11eb-8a11-dd291254a812.mov
