### PR TITLE
feat: remove localBackupRepoID from cloned sites

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -124,4 +124,12 @@ export default function (): void {
 	listenerConfigs.forEach(({ channel, callback }) => {
 		LocalMain.addIpcAsyncListener(channel, callback);
 	});
+
+	LocalMain.HooksMain.addFilter(
+		'updateCloneSiteMetadata',
+		(site: Site) => {
+			delete site.localBackupRepoID;
+			return site;
+		},
+	);
 }


### PR DESCRIPTION
## Summary

This fixes a bug where cloning a site in Local resulted in any Cloud Backups associated with the origin site carrying over to the cloned site.

## Technical

Hooks into the "updateCloneSiteMetadata" filter hook in flywheel-local, and removes the localBackupRepoID associated with the clone site.

## Reference

Sister PR is here: https://github.com/getflywheel/flywheel-local/pull/1134

- https://wpengine.atlassian.net/browse/LOC-2875