### PR TITLE
Edit backup description

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ export const IPCASYNC_EVENTS = {
 	RESTORE_BACKUP: 'backups:restore-backup',
 	CLONE_BACKUP: 'backups:restore-site-clone',
 	CHECK_FOR_DUPLICATE_NAME: 'backups:check-for-duplicate-sitename',
+	EDIT_BACKUP_DESCRIPTION: 'backups:edit-backup-description',
 };
 
 export const metaDataFileName = '.local-backups-site-meta-data.json';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,3 +15,6 @@ export const IPCASYNC_EVENTS = {
 export const metaDataFileName = '.local-backups-site-meta-data.json';
 
 export const backupSQLDumpFile = 'local-backup-addon-database-dump.sql';
+
+// max char length for form inputs
+export const INPUT_MAX = 50;

--- a/src/main.ts
+++ b/src/main.ts
@@ -128,13 +128,23 @@ export default function (): void {
 		},
 		{
 			channel: IPCASYNC_EVENTS.EDIT_BACKUP_DESCRIPTION,
-			callback: async ({ metaData, snapshot }: {metaData: SiteMetaData, snapshot: BackupSnapshot }) => {
-				await updateBackupSnapshot({
-					metaData,
-					snapshotID: snapshot.id,
-					resticSnapshotHash: snapshot.hash,
-					status: 'complete',
-				});
+			callback: async ({ metaData, snapshot, siteId }: { metaData: SiteMetaData, snapshot: BackupSnapshot, siteId: string }) => {
+				try {
+					const result = await updateBackupSnapshot({
+						metaData,
+						snapshotID: snapshot.id,
+						resticSnapshotHash: snapshot.hash,
+						status: 'complete',
+					});
+
+					return createIpcAsyncResult(
+						{ ...result, metaData },
+						siteId,
+					);
+				} catch (error) {
+					logger.error(`Error - IPCASYNC_EVENTS.EDIT_BACKUP_DESCRIPTON: ${error.toString()}`);
+					return createIpcAsyncError(error, siteId);
+				}
 			},
 		},
 	];

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,11 @@
 import * as Local from '@getflywheel/local';
 import * as LocalMain from '@getflywheel/local/main';
-import type { HubOAuthProviders, Providers, Site } from './types';
+import type { BackupSnapshot, HubOAuthProviders, Providers, Site, SiteMetaData } from './types';
 import {
 	getEnabledBackupProviders,
 	getBackupReposByProviderID,
 	getBackupSnapshotsByRepo,
+	updateBackupSnapshot,
 } from './main/hubQueries';
 import { createBackup } from './main/services/backupService';
 import { restoreFromBackup } from './main/services/restoreService';
@@ -124,6 +125,17 @@ export default function (): void {
 			channel: IPCASYNC_EVENTS.CHECK_FOR_DUPLICATE_NAME,
 			callback: async (siteName: string) =>
 				await checkForDuplicateSiteName(siteName),
+		},
+		{
+			channel: IPCASYNC_EVENTS.EDIT_BACKUP_DESCRIPTION,
+			callback: async ({ metaData, snapshot }: {metaData: SiteMetaData, snapshot: BackupSnapshot }) => {
+				await updateBackupSnapshot({
+					metaData,
+					snapshotID: snapshot.id,
+					resticSnapshotHash: snapshot.hash,
+					status: 'complete',
+				});
+			},
 		},
 	];
 

--- a/src/main/hubQueries.ts
+++ b/src/main/hubQueries.ts
@@ -200,13 +200,13 @@ export async function createBackupSnapshot (repoID: number, metaData: SiteMetaDa
 	return { ...rest, repoID: repo_id };
 }
 
-export async function updateBackupSnapshot (queryArgs: { snapshotID: number, resticSnapshotHash?: string, status: SnapshotStatus }): Promise<BackupSnapshot> {
-	const { snapshotID, resticSnapshotHash, status } = queryArgs;
-
+export async function updateBackupSnapshot (queryArgs: { snapshotID: number, resticSnapshotHash?: string, status: SnapshotStatus, metaData?: SiteMetaData }): Promise<BackupSnapshot> {
+	const { snapshotID, resticSnapshotHash, status, metaData } = queryArgs;
+	console.log('queryArgs: ', queryArgs);
 	const { data } = await localHubClient.mutate({
 		mutation: gql`
-			mutation updateBackupSnapshot($snapshotID: Int!, $resticSnapshotHash: String, $status: String!) {
-				updateBackupSnapshot(id: $snapshotID, hash: $resticSnapshotHash, status: $status) {
+			mutation updateBackupSnapshot($snapshotID: Int!, $resticSnapshotHash: String, $status: String!, $metaData: Mixed) {
+				updateBackupSnapshot(id: $snapshotID, hash: $resticSnapshotHash, status: $status, config: $metaData) {
 					id
 					repo_id
 					hash
@@ -217,9 +217,10 @@ export async function updateBackupSnapshot (queryArgs: { snapshotID: number, res
 			snapshotID,
 			resticSnapshotHash,
 			status,
+			metaData: JSON.stringify(metaData),
 		},
 	});
-
+	console.log('data: ', data);
 	const { repo_id: repoID, ...rest } = data?.updateBackupSnapshot;
 	return { ...rest, repoID };
 }

--- a/src/main/hubQueries.ts
+++ b/src/main/hubQueries.ts
@@ -196,13 +196,14 @@ export async function createBackupSnapshot (repoID: number, metaData: SiteMetaDa
 
 	// eslint-disable-next-line camelcase
 	const { repo_id, ...rest } = data?.createBackupSnapshot;
+
 	// eslint-disable-next-line camelcase
 	return { ...rest, repoID: repo_id };
 }
 
 export async function updateBackupSnapshot (queryArgs: { snapshotID: number, resticSnapshotHash?: string, status: SnapshotStatus, metaData?: SiteMetaData }): Promise<BackupSnapshot> {
 	const { snapshotID, resticSnapshotHash, status, metaData } = queryArgs;
-	console.log('queryArgs: ', queryArgs);
+
 	const { data } = await localHubClient.mutate({
 		mutation: gql`
 			mutation updateBackupSnapshot($snapshotID: Int!, $resticSnapshotHash: String, $status: String!, $metaData: Mixed) {
@@ -220,8 +221,9 @@ export async function updateBackupSnapshot (queryArgs: { snapshotID: number, res
 			metaData: JSON.stringify(metaData),
 		},
 	});
-	console.log('data: ', data);
+
 	const { repo_id: repoID, ...rest } = data?.updateBackupSnapshot;
+
 	return { ...rest, repoID };
 }
 

--- a/src/renderer/components/modals/BackupContents.scss
+++ b/src/renderer/components/modals/BackupContents.scss
@@ -38,3 +38,4 @@
 		box-shadow: inset 0 0 0 2px $red !important;
 	}
 }
+

--- a/src/renderer/components/modals/BackupContents.tsx
+++ b/src/renderer/components/modals/BackupContents.tsx
@@ -11,6 +11,7 @@ import type { Site } from '@getflywheel/local';
 import styles from './BackupContents.scss';
 import { fetchSiteSizeInMB } from './fetchSiteSizeInMB';
 import { getIgnoreFilePath } from '../../../helpers/ignoreFilesPattern';
+import { INPUT_MAX } from '../../../constants';
 
 const remote = require('@electron/remote');
 
@@ -76,7 +77,7 @@ export const BackupContents = (props: ModalContentsProps) => {
 				<BasicInput
 					value={inputDescriptionData}
 					onChange={onInputChange}
-					maxlength={50}
+					maxlength={INPUT_MAX}
 				/>
 
 				<Title size="m" style={{ paddingTop: 15 }}>Ignore files</Title>

--- a/src/renderer/components/modals/BackupEditDescriptionContents.scss
+++ b/src/renderer/components/modals/BackupEditDescriptionContents.scss
@@ -1,0 +1,3 @@
+.Divider {
+	margin: 30px 0;
+}

--- a/src/renderer/components/modals/BackupEditDescriptionContents.tsx
+++ b/src/renderer/components/modals/BackupEditDescriptionContents.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { BasicInput, Title, Divider, PrimaryButton } from '@getflywheel/local-components';
+import styles from './BackupEditDescriptionContents.scss';
+
+export const BackupEditDescriptionContents = () => {
+	return (
+		<div>
+			<Title size="l" container={{ margin: 'm 0' }}>
+				Edit Cloud Backup description
+			</Title>
+			<Divider className={styles.Divider} />
+			<BasicInput />
+			<PrimaryButton>
+				Update Description
+			</PrimaryButton>
+		</div>
+	)
+};
+

--- a/src/renderer/components/modals/BackupEditDescriptionContents.tsx
+++ b/src/renderer/components/modals/BackupEditDescriptionContents.tsx
@@ -1,12 +1,15 @@
-import React, { useState } from 'react';
-import { BasicInput, Title, Divider, PrimaryButton } from '@getflywheel/local-components';
+import React, { useEffect, useState } from 'react';
+import {
+	FlyModal,
+	BasicInput,
+	Title,
+	Divider,
+	PrimaryButton,
+} from '@getflywheel/local-components';
 import styles from './BackupEditDescriptionContents.scss';
-import { ipcAsync } from '@getflywheel/local/renderer';
 import type { Site } from '@getflywheel/local';
 import { BackupSnapshot } from '../../../types';
-import { IPCASYNC_EVENTS } from '../../../constants';
 import { actions, store } from '../../store/store';
-
 export interface ModalContentsProps {
 	site: Site;
 	snapshot: BackupSnapshot;
@@ -15,14 +18,14 @@ export interface ModalContentsProps {
 export const BackupEditDescriptionContents = (props: ModalContentsProps) => {
 	const [description, updateDescription] = useState('');
 
-	const updateDescriptionGQL = async () => {
-		await ipcAsync(
-			IPCASYNC_EVENTS.EDIT_BACKUP_DESCRIPTION,
-			{
-				metaData: { ...props.snapshot.configObject, description },
-				snapshot: props.snapshot,
-			},
-		);
+	const updateDescriptionGQL = () => {
+		store.dispatch(actions.editSnapshotMetaData({
+			siteId: props.site.id,
+			metaData: { ...props.snapshot.configObject, description },
+			snapshot: props.snapshot,
+		}));
+
+		FlyModal.onRequestClose();
 	};
 
 	return (
@@ -32,8 +35,11 @@ export const BackupEditDescriptionContents = (props: ModalContentsProps) => {
 			</Title>
 			<Divider className={styles.Divider} />
 			<BasicInput
+				autoFocus
 				value={description}
+				placeholder={props.snapshot.configObject.description}
 				onChange={(e) => updateDescription(e.target.value)}
+				maxLength={50}
 			/>
 			<PrimaryButton
 				onClick={updateDescriptionGQL}

--- a/src/renderer/components/modals/BackupEditDescriptionContents.tsx
+++ b/src/renderer/components/modals/BackupEditDescriptionContents.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import {
 	FlyModal,
 	BasicInput,
@@ -47,6 +47,5 @@ export const BackupEditDescriptionContents = (props: ModalContentsProps) => {
 				Update Description
 			</PrimaryButton>
 		</div>
-	)
+	);
 };
-

--- a/src/renderer/components/modals/BackupEditDescriptionContents.tsx
+++ b/src/renderer/components/modals/BackupEditDescriptionContents.tsx
@@ -34,7 +34,7 @@ export const BackupEditDescriptionContents = (props: ModalContentsProps) => {
 	return (
 		<div>
 			<Title size="l" container={{ margin: 'm 0' }}>
-				Edit Cloud Backup description
+				Edit backup description
 			</Title>
 			<Divider className={styles.Divider} />
 			<BasicInput

--- a/src/renderer/components/modals/BackupEditDescriptionContents.tsx
+++ b/src/renderer/components/modals/BackupEditDescriptionContents.tsx
@@ -17,12 +17,14 @@ export interface ModalContentsProps {
 
 export const BackupEditDescriptionContents = (props: ModalContentsProps) => {
 	const [description, updateDescription] = useState('');
+	const { site, snapshot } = props;
+	const { configObject } = snapshot;
 
 	const updateDescriptionGQL = () => {
 		store.dispatch(actions.editSnapshotMetaData({
-			siteId: props.site.id,
-			metaData: { ...props.snapshot.configObject, description },
-			snapshot: props.snapshot,
+			siteId: site.id,
+			metaData: { ...configObject, description },
+			snapshot: snapshot,
 		}));
 
 		FlyModal.onRequestClose();
@@ -37,7 +39,7 @@ export const BackupEditDescriptionContents = (props: ModalContentsProps) => {
 			<BasicInput
 				autoFocus
 				value={description}
-				placeholder={props.snapshot.configObject.description}
+				placeholder={configObject.description}
 				onChange={(e) => updateDescription(e.target.value)}
 				maxLength={50}
 			/>

--- a/src/renderer/components/modals/BackupEditDescriptionContents.tsx
+++ b/src/renderer/components/modals/BackupEditDescriptionContents.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import {
 	FlyModal,
 	BasicInput,
@@ -10,6 +10,7 @@ import styles from './BackupEditDescriptionContents.scss';
 import type { Site } from '@getflywheel/local';
 import { BackupSnapshot } from '../../../types';
 import { actions, store } from '../../store/store';
+import { INPUT_MAX } from '../../../constants';
 export interface ModalContentsProps {
 	site: Site;
 	snapshot: BackupSnapshot;
@@ -20,7 +21,7 @@ export const BackupEditDescriptionContents = (props: ModalContentsProps) => {
 	const { site, snapshot } = props;
 	const { configObject } = snapshot;
 
-	const updateDescriptionGQL = () => {
+	const updateDescriptionGQL = useCallback(() => {
 		store.dispatch(actions.editSnapshotMetaData({
 			siteId: site.id,
 			metaData: { ...configObject, description },
@@ -28,7 +29,7 @@ export const BackupEditDescriptionContents = (props: ModalContentsProps) => {
 		}));
 
 		FlyModal.onRequestClose();
-	};
+	}, [description]);
 
 	return (
 		<div>
@@ -41,7 +42,7 @@ export const BackupEditDescriptionContents = (props: ModalContentsProps) => {
 				value={description}
 				placeholder={configObject.description}
 				onChange={(e) => updateDescription(e.target.value)}
-				maxLength={50}
+				maxLength={INPUT_MAX}
 			/>
 			<PrimaryButton
 				onClick={updateDescriptionGQL}

--- a/src/renderer/components/modals/BackupEditDescriptionContents.tsx
+++ b/src/renderer/components/modals/BackupEditDescriptionContents.tsx
@@ -1,16 +1,43 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { BasicInput, Title, Divider, PrimaryButton } from '@getflywheel/local-components';
 import styles from './BackupEditDescriptionContents.scss';
+import { ipcAsync } from '@getflywheel/local/renderer';
+import type { Site } from '@getflywheel/local';
+import { BackupSnapshot } from '../../../types';
+import { IPCASYNC_EVENTS } from '../../../constants';
+import { actions, store } from '../../store/store';
 
-export const BackupEditDescriptionContents = () => {
+export interface ModalContentsProps {
+	site: Site;
+	snapshot: BackupSnapshot;
+}
+
+export const BackupEditDescriptionContents = (props: ModalContentsProps) => {
+	const [description, updateDescription] = useState('');
+
+	const updateDescriptionGQL = async () => {
+		await ipcAsync(
+			IPCASYNC_EVENTS.EDIT_BACKUP_DESCRIPTION,
+			{
+				metaData: { ...props.snapshot.configObject, description },
+				snapshot: props.snapshot,
+			},
+		);
+	};
+
 	return (
 		<div>
 			<Title size="l" container={{ margin: 'm 0' }}>
 				Edit Cloud Backup description
 			</Title>
 			<Divider className={styles.Divider} />
-			<BasicInput />
-			<PrimaryButton>
+			<BasicInput
+				value={description}
+				onChange={(e) => updateDescription(e.target.value)}
+			/>
+			<PrimaryButton
+				onClick={updateDescriptionGQL}
+			>
 				Update Description
 			</PrimaryButton>
 		</div>

--- a/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
+++ b/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
@@ -200,6 +200,16 @@ const LoadMoreWhenVisibleCell = ({ site }) => {
 	);
 };
 
+const renderDescription = (description?: string) => {
+	if (!description) {
+		return (
+			<LoadingIndicator style={{ margin: 0 }} dots={3} />
+		);
+	}
+
+	return description;
+};
+
 const renderCell = (dataArgs: IVirtualTableCellRendererDataArgs) => {
 	const { colKey, cellData, isHeader, extraData } = dataArgs;
 	const { site, provider } = extraData;
@@ -230,7 +240,7 @@ const renderCell = (dataArgs: IVirtualTableCellRendererDataArgs) => {
 	}
 
 	switch (colKey) {
-		case 'configObject': return cellData.description;
+		case 'configObject': return renderDescription(cellData.description);
 		case 'moremenu': return renderCellMoreMenu(snapshot, site, provider);
 		case 'updatedAt': return renderDate(cellData, snapshot);
 	}

--- a/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
+++ b/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
@@ -201,7 +201,7 @@ const LoadMoreWhenVisibleCell = ({ site }) => {
 };
 
 const renderDescription = (description?: string) => {
-	if (!description) {
+	if (description === null) {
 		return (
 			<LoadingIndicator style={{ margin: 0 }} color="Gray" />
 		);

--- a/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
+++ b/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
@@ -16,6 +16,7 @@ import DateUtils from '../../helpers/DateUtils';
 import type { Site } from '@getflywheel/local';
 import { BackupCloneContents } from '../modals/BackupCloneContents';
 import { BackupRestoreContents } from '../modals/BackupRestoreContents';
+import { BackupEditDescriptionContents } from '../modals/BackupEditDescriptionContents';
 import { createModal } from '../createModal';
 import { selectors } from '../../store/selectors';
 import {
@@ -143,6 +144,17 @@ const renderCellMoreMenu = (snapshot: BackupSnapshot, site: Site, provider: HubP
 								snapshot={snapshot}
 								provider={provider}
 							/>
+						),
+					),
+			});
+			items.push({
+				color: 'none',
+				content: renderTextButton('Edit backup description', () => store.getState().director.backupIsRunning),
+				onClick: store.getState().director.backupIsRunning
+					? () => undefined
+					: () => createModal(
+						() => (
+							<BackupEditDescriptionContents />
 						),
 					),
 			});

--- a/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
+++ b/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
@@ -154,7 +154,10 @@ const renderCellMoreMenu = (snapshot: BackupSnapshot, site: Site, provider: HubP
 					? () => undefined
 					: () => createModal(
 						() => (
-							<BackupEditDescriptionContents />
+							<BackupEditDescriptionContents
+								site={site}
+								snapshot={snapshot}
+							/>
 						),
 					),
 			});

--- a/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
+++ b/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
@@ -203,7 +203,7 @@ const LoadMoreWhenVisibleCell = ({ site }) => {
 const renderDescription = (description?: string) => {
 	if (!description) {
 		return (
-			<LoadingIndicator style={{ margin: 0 }} dots={3} />
+			<LoadingIndicator style={{ margin: 0 }} color="Gray" />
 		);
 	}
 

--- a/src/renderer/store/snapshotsSlice.ts
+++ b/src/renderer/store/snapshotsSlice.ts
@@ -1,7 +1,7 @@
 import { createEntityAdapter, createSelector, createSlice } from '@reduxjs/toolkit';
 import type { EntityState } from '@reduxjs/toolkit';
-import type { BackupSnapshot, PaginationInfo } from '../../types';
-import { clearSnapshotsForSite, getSnapshotsForActiveSiteProviderHub } from './thunks';
+import type { BackupSnapshot, PaginationInfo, SiteMetaData } from '../../types';
+import { clearSnapshotsForSite, getSnapshotsForActiveSiteProviderHub, editSnapshotMetaData } from './thunks';
 import type { AppState } from './store';
 import { selectors } from './selectors';
 
@@ -97,6 +97,18 @@ export const snapshotsSlice = createSlice({
 				hasLoadingError: true,
 				isLoading: false,
 			};
+		});
+		builder.addCase(editSnapshotMetaData.fulfilled, (state, { meta, payload }) => {
+			const { snapshot }: { snapshot: BackupSnapshot } = meta.arg;
+			const { metaData }: { metaData: SiteMetaData } = payload.result;
+
+			snapshotsEntityAdapter.upsertOne(state.items, {
+				...snapshot,
+				configObject: {
+					...snapshot.configObject,
+					...metaData,
+				},
+			});
 		});
 	},
 });

--- a/src/renderer/store/snapshotsSlice.ts
+++ b/src/renderer/store/snapshotsSlice.ts
@@ -110,6 +110,17 @@ export const snapshotsSlice = createSlice({
 				},
 			});
 		});
+		builder.addCase(editSnapshotMetaData.pending, (state, { meta, payload }) => {
+			const { snapshot }: { snapshot: BackupSnapshot } = meta.arg;
+
+			snapshotsEntityAdapter.upsertOne(state.items, {
+				...snapshot,
+				configObject: {
+					...snapshot.configObject,
+					description: null,
+				},
+			});
+		});
 	},
 });
 

--- a/src/renderer/store/thunks.ts
+++ b/src/renderer/store/thunks.ts
@@ -35,6 +35,15 @@ const editSnapshotMetaData = createAsyncThunk<
 			siteId,
 			rejectWithValue,
 			(details) => {
+				if (details.isResult) {
+					showSiteBanner({
+						siteID: details.siteId,
+						variant: 'success',
+						id: details.bannerId,
+						message: `Backup description updated.`,
+					});
+				}
+
 				if (details.isErrorAndUncaptured) {
 					showSiteBanner({
 						icon: 'warning',


### PR DESCRIPTION
Add ability to edit a backup description!

- Adds `editSnapshotMetaData` thunk which kicks off the `graphql` mutation flow & updates the snapshot description on hub
- Adds the `editSnapshotMetaData.fulfilled` & `editSnapshotMetaData.pending` extra reducers to the `snapshotsSlice` to update UI with updated description
- Shows an error banner if there's an issue updating the description


https://user-images.githubusercontent.com/10208759/127187999-148e72ce-9001-499e-b165-7e8a97099117.mov
