### PR TITLE
fix: add .txt extension to ignore file

### DIFF
--- a/src/helpers/ignoreFilesPattern.ts
+++ b/src/helpers/ignoreFilesPattern.ts
@@ -6,7 +6,7 @@ import type { Site } from '../types';
 
 export const excludePatterns = ['conf'];
 
-export const localBackupsIgnoreFileName = '.localbackupaddonignore';
+export const localBackupsIgnoreFileName = '.localbackupaddonignore.txt';
 
 // Returns an array of directories within the site folder that we want to include in the backup
 // Filters out the 'conf' directory and any `.` files

--- a/src/helpers/ignoreFilesPattern.ts
+++ b/src/helpers/ignoreFilesPattern.ts
@@ -23,7 +23,7 @@ export const getFilteredSiteFiles = (site: Site) => {
 
 // returns the path to the site specific ignore file for the site backup
 // handles copying the default ignore file into the site prior to site backup
-export const getIgnoreFilePath = (site: Site) => {
+export const getIgnoreFilePath = async (site: Site) => {
 	let defaultIgnoreFilePath = path.join(__dirname, '..', 'resources', 'default-ignore-file');
 
 	if (!fs.existsSync(defaultIgnoreFilePath)) {
@@ -32,7 +32,14 @@ export const getIgnoreFilePath = (site: Site) => {
 
 	const expandedSitePath = formatHomePath(site.path);
 
+	const formerLocalBackupsIgnoreFileName = '.localbackupaddonignore';
+
+	const formerIgnoreFilePath = path.join(expandedSitePath, formerLocalBackupsIgnoreFileName);
 	const ignoreFilePath = path.join(expandedSitePath, localBackupsIgnoreFileName);
+
+	if (fs.existsSync(formerIgnoreFilePath)) {
+		await fs.rename(formerIgnoreFilePath, ignoreFilePath);
+	}
 
 	if (!fs.existsSync(ignoreFilePath)) {
 		fs.copySync(defaultIgnoreFilePath, ignoreFilePath);

--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -223,7 +223,7 @@ export async function createSnapshot (site: Site, provider: Providers, encryptio
 		throw new Error(`No backup repo id found for ${site.name}`);
 	}
 
-	const ignoreFilePath = getIgnoreFilePath(site);
+	const ignoreFilePath = await getIgnoreFilePath(site);
 
 	const flags = [
 		'--json',

--- a/src/renderer/components/modals/BackupContents.tsx
+++ b/src/renderer/components/modals/BackupContents.tsx
@@ -48,7 +48,7 @@ export const BackupContents = (props: ModalContentsProps) => {
 	};
 
 	const onClickEditIgnore = async (site: Site) => {
-		const ignoreFilePath = getIgnoreFilePath(site);
+		const ignoreFilePath = await getIgnoreFilePath(site);
 		shell.openPath(ignoreFilePath);
 	};
 


### PR DESCRIPTION
Adding the `.txt` extension sets Notepad as the default app when users try to edit the file.