### PR TITLE
feat: add multi-machine restore from backup workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "@apollo/client": "^3.3.15",
     "@electron/remote": "^1.1.0",
-    "@getflywheel/local-components": "16.1.1",
+    "@getflywheel/local-components": "16.2.3",
     "@reduxjs/toolkit": "^1.5.0",
     "classnames": "^2.2.6",
     "cross-fetch": "^3.1.4",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,14 @@ export const MULTI_MACHINE_BACKUP_ERRORS = {
 	NO_CONNECTED_PROVIDERS_FOR_SITE: 'No connected providers found for this site!',
 };
 
+export const LOCAL_ROUTES = {
+	ADD_SITE_START: '/main/add-site',
+	ADD_SITE_BACKUP_SITE: '/main/add-site/select-site-backup',
+	ADD_SITE_BACKUP_SNAPSHOT: '/main/add-site/select-snapshot',
+	ADD_SITE_ENVIRONMENT: '/main/add-site/environment',
+	ADD_SITE_CREATE_NEW: '/main/add-site/add',
+};
+
 export const metaDataFileName = '.local-backups-site-meta-data.json';
 
 export const backupSQLDumpFile = 'local-backup-addon-database-dump.sql';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,7 @@ export const IPCASYNC_EVENTS = {
 	EDIT_BACKUP_DESCRIPTION: 'backups:edit-backup-description',
 	GET_ALL_SITES: 'backups:get-all-sites-for-user',
 	GET_ALL_SNAPSHOTS: 'backup:get-all-snapshots-for-site',
+	GET_REPOS_BY_SITE_ID: 'backup:get-repos-by-site-id',
 	MULTI_MACHINE_GET_AVAILABLE_PROVIDERS: 'backup:get-enabled-providers-multi-machine',
 };
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,8 @@ export const IPCASYNC_EVENTS = {
 	CHECK_FOR_DUPLICATE_NAME: 'backups:check-for-duplicate-sitename',
 	EDIT_BACKUP_DESCRIPTION: 'backups:edit-backup-description',
 	GET_ALL_SITES: 'backups:get-all-sites-for-user',
+	GET_ALL_SNAPSHOTS: 'backup:get-all-snapshots-for-site',
+	MULTI_MACHINE_GET_AVAILABLE_PROVIDERS: 'backup:get-enabled-providers-multi-machine',
 };
 
 export const metaDataFileName = '.local-backups-site-meta-data.json';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,7 @@ export const IPCASYNC_EVENTS = {
 	CLONE_BACKUP: 'backups:restore-site-clone',
 	CHECK_FOR_DUPLICATE_NAME: 'backups:check-for-duplicate-sitename',
 	EDIT_BACKUP_DESCRIPTION: 'backups:edit-backup-description',
+	GET_ALL_SITES: 'backups:get-all-sites-for-user',
 };
 
 export const metaDataFileName = '.local-backups-site-meta-data.json';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,20 +11,23 @@ export const IPCASYNC_EVENTS = {
 	CHECK_FOR_DUPLICATE_NAME: 'backups:check-for-duplicate-sitename',
 	EDIT_BACKUP_DESCRIPTION: 'backups:edit-backup-description',
 	GET_ALL_SITES: 'backups:get-all-sites-for-user',
-	GET_ALL_SNAPSHOTS: 'backup:get-all-snapshots-for-site',
-	GET_REPOS_BY_SITE_ID: 'backup:get-repos-by-site-id',
-	MULTI_MACHINE_GET_AVAILABLE_PROVIDERS: 'backup:get-enabled-providers-multi-machine',
+	GET_ALL_SNAPSHOTS: 'backups:get-all-snapshots-for-site',
+	GET_REPOS_BY_SITE_ID: 'backups:get-repos-by-site-id',
+	MULTI_MACHINE_GET_AVAILABLE_PROVIDERS: 'backups:get-enabled-providers-multi-machine',
+	SHOULD_LOAD_PROMO_BANNER: 'backups:should-load-promo-banner',
+	REMOVE_PROMO_BANNER: 'backups:remove-promo-banner',
 };
 
 export const MULTI_MACHINE_BACKUP_ERRORS = {
 	// User has no connected backup providers on Hub
-	NO_PROVIDERS_FOUND: 'No providers found!',
+	NO_PROVIDERS_FOUND: 'No connected storage providers found for your Local account! Please connect at least one and try again.',
 	// User has not created any site backups on Hub
-	NO_SITES_FOUND: 'No sites found!',
+	NO_SITES_FOUND: 'No site backups found for your Local account user! Please create one or try another account.',
 	// User created a backup, and then disconnected the provider so the backups are inaccessible
-	NO_SNAPSHOTS_FOUND: 'No snapshots found!',
+	NO_SNAPSHOTS_FOUND: 'We couldn\'t find any backups created for this site. Please try another provider or Local account.',
 	// Same as above
 	NO_CONNECTED_PROVIDERS_FOR_SITE: 'No connected providers found for this site!',
+	GENERIC_HUB_CONNECTION_ERROR: 'We could not authenticate your connection. Please verify you are logged into your Local account and try again.',
 };
 
 export const LOCAL_ROUTES = {
@@ -34,6 +37,8 @@ export const LOCAL_ROUTES = {
 	ADD_SITE_ENVIRONMENT: '/main/add-site/environment',
 	ADD_SITE_CREATE_NEW: '/main/add-site/add',
 };
+
+export const SHOW_CLOUD_BACKUPS_PROMO_BANNER = 'showCloudBackupsPromoBanner';
 
 export const metaDataFileName = '.local-backups-site-meta-data.json';
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,13 @@ export const IPCASYNC_EVENTS = {
 	MULTI_MACHINE_GET_AVAILABLE_PROVIDERS: 'backup:get-enabled-providers-multi-machine',
 };
 
+export const MULTI_MACHINE_BACKUP_ERRORS = {
+	NO_PROVIDERS_FOUND: 'No providers found!',
+	NO_SITES_FOUND: 'No sites found!',
+	NO_SNAPSHOTS_FOUND: 'No snapshots found!',
+	NO_CONNECTED_PROVIDERS_FOR_SITE: 'No connected providers found for this site!',
+};
+
 export const metaDataFileName = '.local-backups-site-meta-data.json';
 
 export const backupSQLDumpFile = 'local-backup-addon-database-dump.sql';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,9 +17,13 @@ export const IPCASYNC_EVENTS = {
 };
 
 export const MULTI_MACHINE_BACKUP_ERRORS = {
+	// User has no connected backup providers on Hub
 	NO_PROVIDERS_FOUND: 'No providers found!',
+	// User has not created any site backups on Hub
 	NO_SITES_FOUND: 'No sites found!',
+	// User created a backup, and then disconnected the provider so the backups are inaccessible
 	NO_SNAPSHOTS_FOUND: 'No snapshots found!',
+	// Same as above
 	NO_CONNECTED_PROVIDERS_FOR_SITE: 'No connected providers found for this site!',
 };
 

--- a/src/helpers/checkForDuplicateSiteName.ts
+++ b/src/helpers/checkForDuplicateSiteName.ts
@@ -6,7 +6,7 @@ const {
 } = serviceContainer;
 
 export const checkForDuplicateSiteName = async (siteName: string) => {
-	const coolSitedata = siteData.getSites();
+	const allSiteData = siteData.getSites();
 
 	const formattedSiteName = formatSiteNicename(siteName);
 	const newSiteDomain = `${formattedSiteName}.local`;
@@ -14,7 +14,7 @@ export const checkForDuplicateSiteName = async (siteName: string) => {
 	let matchesExistingDomains = false;
 	let matchesExistingNames = false;
 
-	for (const site of Object.values(coolSitedata)) {
+	for (const site of Object.values(allSiteData)) {
 		if (site.domain === newSiteDomain) {
 			matchesExistingDomains = true;
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ import {
 } from './main/hubQueries';
 import { createBackup } from './main/services/backupService';
 import { restoreFromBackup } from './main/services/restoreService';
-import { getSiteDataFromDisk } from './main/utils';
+import { getSiteDataFromDisk, hubProviderRecordToProvider } from './main/utils';
 import { cloneFromBackup } from './main/services/cloneFromBackupService';
 import { IPCASYNC_EVENTS } from './constants';
 import { createIpcAsyncError, createIpcAsyncResult } from './helpers/createIpcAsyncResponse';
@@ -225,15 +225,11 @@ export default function (): void {
 	LocalMain.HooksMain.addAction(
 		'siteAdded',
 		async (site: Site) => {
-			console.log(site);
 			const { provider, snapshotID, repoID } = site.cloudBackupMeta;
 
-			if (provider === HubProviderNames.Google) {
-				return await restoreFromBackup({ site, provider: ProviderNames.Drive, snapshotID, repoID });
-			}
-			// todo - tyler - clean up this typing so the default provider isn't dropbox
-			return await restoreFromBackup({ site, provider: ProviderNames.Dropbox, snapshotID, repoID });
+			const providerID = hubProviderRecordToProvider(provider);
 
+			return await restoreFromBackup({ site, provider: providerID, snapshotID, repoID });
 			// todo - tyler - after running restore from backup, update hosts file with new domain url
 		},
 	);

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import {
 	getBackupReposByProviderID,
 	getBackupSnapshotsByRepo,
 	updateBackupSnapshot,
+	getAllBackupSites,
 } from './main/hubQueries';
 import { createBackup } from './main/services/backupService';
 import { restoreFromBackup } from './main/services/restoreService';
@@ -146,6 +147,11 @@ export default function (): void {
 					return createIpcAsyncError(error, siteId);
 				}
 			},
+		},
+		{
+			channel: IPCASYNC_EVENTS.GET_ALL_SITES,
+			callback: async () =>
+				await getAllBackupSites(),
 		},
 	];
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -173,6 +173,12 @@ export default function (): void {
 
 				if (repoID) {
 					const snapshots = await getBackupSnapshotsByRepo(repoID, 20, 0);
+
+					// Hub returns the "config" data as a single string, so we need to convert back to object
+					snapshots.snapshots.forEach((snapshot) => {
+						snapshot.configObject = JSON.parse(snapshot.config);
+					});
+
 					return snapshots;
 				}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ import { createBackup } from './main/services/backupService';
 import { restoreFromBackup } from './main/services/restoreService';
 import { getSiteDataFromDisk, hubProviderRecordToProvider } from './main/utils';
 import { cloneFromBackup } from './main/services/cloneFromBackupService';
-import { IPCASYNC_EVENTS } from './constants';
+import { IPCASYNC_EVENTS, SHOW_CLOUD_BACKUPS_PROMO_BANNER } from './constants';
 import { createIpcAsyncError, createIpcAsyncResult } from './helpers/createIpcAsyncResponse';
 import { getServiceContainer } from '@getflywheel/local/main';
 import { checkForDuplicateSiteName } from './helpers/checkForDuplicateSiteName';
@@ -220,6 +220,14 @@ export default function (): void {
 				return [];
 			},
 		},
+		{
+			channel: IPCASYNC_EVENTS.SHOULD_LOAD_PROMO_BANNER,
+			callback: async () => await LocalMain.UserData.get(SHOW_CLOUD_BACKUPS_PROMO_BANNER),
+		},
+		{
+			channel: IPCASYNC_EVENTS.REMOVE_PROMO_BANNER,
+			callback: async () => await LocalMain.UserData.remove(SHOW_CLOUD_BACKUPS_PROMO_BANNER),
+		},
 	];
 
 	listenerConfigs.forEach(({ channel, callback }) => {
@@ -256,4 +264,14 @@ export default function (): void {
 			}
 		},
 	);
+
+	LocalMain.HooksMain.addFilter('migrations', (defaultMigrations) => ({
+		...defaultMigrations,
+		cloudBackupsAddon: {
+			label: 'Cloud Backups Addon Migration',
+			migrate: () => {
+				LocalMain.UserData.set(SHOW_CLOUD_BACKUPS_PROMO_BANNER, { show: true });
+			},
+		},
+	}));
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -207,7 +207,7 @@ export default function (): void {
 				});
 
 				if (repoID) {
-					const snapshots = await getBackupSnapshotsByRepo(repoID, 3, paginationNumber);
+					const snapshots = await getBackupSnapshotsByRepo(repoID, SNAPSHOTS_PAGE_LIMIT, paginationNumber);
 
 					// Hub returns the "config" data as a single string, so we need to convert back to object
 					snapshots.snapshots.forEach((snapshot) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -175,8 +175,10 @@ export default function (): void {
 		},
 		{
 			channel: IPCASYNC_EVENTS.GET_ALL_SNAPSHOTS,
-			callback: async (siteUUID: string, provider: HubOAuthProviders) => {
+			callback: async (siteUUID: string, provider: HubOAuthProviders, requestedPage?: number) => {
 				const repos = await getBackupReposByProviderID(provider);
+
+				const paginationNumber = requestedPage ? requestedPage : 0;
 
 				let repoID: number;
 
@@ -187,7 +189,7 @@ export default function (): void {
 				});
 
 				if (repoID) {
-					const snapshots = await getBackupSnapshotsByRepo(repoID, 20, 0);
+					const snapshots = await getBackupSnapshotsByRepo(repoID, 3, paginationNumber);
 
 					// Hub returns the "config" data as a single string, so we need to convert back to object
 					snapshots.snapshots.forEach((snapshot) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -196,7 +196,7 @@ export default function (): void {
 			callback: async (siteUUID: string, provider: HubOAuthProviders, requestedPage?: number) => {
 				const repos = await getBackupReposByProviderID(provider);
 
-				const paginationNumber = requestedPage ? requestedPage : 0;
+				const paginationNumber = requestedPage ?? 0;
 
 				let repoID: number;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -153,6 +153,32 @@ export default function (): void {
 			callback: async () =>
 				await getAllBackupSites(),
 		},
+		{
+			channel: IPCASYNC_EVENTS.MULTI_MACHINE_GET_AVAILABLE_PROVIDERS,
+			callback: async () =>
+				await getEnabledBackupProviders(),
+		},
+		{
+			channel: IPCASYNC_EVENTS.GET_ALL_SNAPSHOTS,
+			callback: async (siteUUID: string, provider: HubOAuthProviders) => {
+				const repos = await getBackupReposByProviderID(provider);
+
+				let repoID: number;
+
+				repos.forEach((repo) => {
+					if (repo.hash === siteUUID) {
+						repoID = repo.id;
+					}
+				});
+
+				if (repoID) {
+					const snapshots = await getBackupSnapshotsByRepo(repoID, 20, 0);
+					return snapshots;
+				}
+
+				return [];
+			},
+		},
 	];
 
 	listenerConfigs.forEach(({ channel, callback }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {
 	getBackupSnapshotsByRepo,
 	updateBackupSnapshot,
 	getAllBackupSites,
+	getBackupReposBySiteID,
 } from './main/hubQueries';
 import { createBackup } from './main/services/backupService';
 import { restoreFromBackup } from './main/services/restoreService';
@@ -155,9 +156,22 @@ export default function (): void {
 				await getAllBackupSites(),
 		},
 		{
+			channel: IPCASYNC_EVENTS.GET_REPOS_BY_SITE_ID,
+			callback: async (siteID: number) =>
+				await getBackupReposBySiteID(siteID),
+		},
+		{
 			channel: IPCASYNC_EVENTS.MULTI_MACHINE_GET_AVAILABLE_PROVIDERS,
-			callback: async () =>
-				await getEnabledBackupProviders(),
+			callback: async () => {
+				try {
+					return await getEnabledBackupProviders();
+				} catch (error) {
+					logger.error(`Error - IPCASYNC_EVENTS.MULTI_MACHINE_GET_AVAILABLE_PROVIDERS: ${error.toString()}`);
+					return error;
+				}
+
+			},
+
 		},
 		{
 			channel: IPCASYNC_EVENTS.GET_ALL_SNAPSHOTS,

--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -17,6 +17,7 @@ interface RestoreFromBackupOptions {
 	snapshotID: string;
 	restoreDir: string;
 	restoringToNewSite?: boolean;
+	repoID?: string;
 }
 
 const bins = getOSBins();
@@ -257,8 +258,12 @@ Fatal: wrong password or no key found
  * @param options
  */
 export async function restoreBackup (options: RestoreFromBackupOptions) {
-	const { site, provider, encryptionPassword, snapshotID, restoreDir, restoringToNewSite } = options;
-	const { localBackupRepoID } = getSiteDataFromDisk(site.id);
+	const { site, provider, encryptionPassword, snapshotID, restoreDir, restoringToNewSite, repoID } = options;
+	let { localBackupRepoID } = getSiteDataFromDisk(site.id);
+
+	if (repoID) {
+		localBackupRepoID = repoID;
+	}
 
 	const flags = [
 		'--json',

--- a/src/main/hubQueries.ts
+++ b/src/main/hubQueries.ts
@@ -58,6 +58,23 @@ export async function getBackupSite (localBackupRepoID: string): Promise<BackupS
 	return data?.backupSites?.[0];
 }
 
+export async function getAllBackupSites (): Promise<BackupSite> {
+	const { data } = await localHubClient.query({
+		query: gql`
+			query getBackupSite ($repoID: String) {
+				backupSites(uuid: $repoID) {
+					id
+					name
+					uuid
+					password
+				}
+			}
+		`,
+	});
+
+	return data?.backupSites;
+}
+
 export async function createBackupSite (site: Site): Promise<BackupSite> {
 	const { data } = await localHubClient.mutate({
 		mutation: gql`

--- a/src/main/hubQueries.ts
+++ b/src/main/hubQueries.ts
@@ -332,10 +332,11 @@ export async function getBackupSnapshotsByRepo (repoId: number, limit: number, o
 
 	return {
 		pagination: data?.backupSnapshots?.paginatorInfo,
-		snapshots: data?.backupSnapshots?.data?.map(({ repo_id: repoID, updated_at: updatedAt, ...rest }) => ({
+		snapshots: data?.backupSnapshots?.data?.map(({ repo_id: repoID, updated_at: updatedAt, created_at: createdAt, ...rest }) => ({
 			...rest,
 			repoID,
 			updatedAt,
+			createdAt,
 		})),
 	};
 }

--- a/src/main/hubQueries.ts
+++ b/src/main/hubQueries.ts
@@ -283,6 +283,7 @@ export async function getBackupSnapshotsByRepo (repoId: number, limit: number, o
 						repo_id
 						hash
 						updated_at
+						created_at
 						config
 					}
 					paginatorInfo {

--- a/src/main/hubQueries.ts
+++ b/src/main/hubQueries.ts
@@ -58,7 +58,7 @@ export async function getBackupSite (localBackupRepoID: string): Promise<BackupS
 	return data?.backupSites?.[0];
 }
 
-export async function getAllBackupSites (): Promise<BackupSite> {
+export async function getBackupSitesByRepoID (repoID: string): Promise<BackupSite> {
 	const { data } = await localHubClient.query({
 		query: gql`
 			query getBackupSite ($repoID: String) {
@@ -70,6 +70,9 @@ export async function getAllBackupSites (): Promise<BackupSite> {
 				}
 			}
 		`,
+		variables: {
+			repoID: repoID,
+		},
 	});
 
 	return data?.backupSites;

--- a/src/main/hubQueries.ts
+++ b/src/main/hubQueries.ts
@@ -179,6 +179,32 @@ export async function getBackupReposByProviderID (provider: HubOAuthProviders): 
 	}));
 }
 
+export async function getBackupReposBySiteID (siteID: number): Promise<BackupRepo[]> {
+	const { data } = await localHubClient.query({
+		query: gql`
+			query getBackupReposBySiteID($siteID: Int) {
+  				backupRepos(site_id: $siteID) {
+    				id
+    				site_id
+    				provider_id
+    				hash
+  				}
+			}
+		`,
+		variables: {
+			siteID: siteID,
+		},
+	});
+
+	return [
+		...data?.backupRepos,
+	].map((backupRepo) => ({
+		...backupRepo,
+		providerID: backupRepo.provider_id,
+		siteID: backupRepo.site_id,
+	}));
+}
+
 export async function getEnabledBackupProviders (): Promise<HubProviderRecord[]> {
 	const { data } = await localHubClient.query({
 		query: gql`

--- a/src/main/services/restoreService.ts
+++ b/src/main/services/restoreService.ts
@@ -310,13 +310,13 @@ export const restoreFromBackup = async (opts: {
 				logger.info(`${actionLabel} [site id: ${site.id}]`);
 			})
 			.onDone(() => restoreService.stop())
-			.onStop(() => {
+			.onStop(async () => {
 				serviceState.inProgressStateMachine = null;
 				// eslint-disable-next-line no-underscore-dangle
 				const error: ErrorState = JSON.parse(restoreService._state.context.error ?? null);
 				const siteModel = new LocalSiteModel(site);
 
-				siteProcessManager.restart(siteModel);
+				await siteProcessManager.restart(siteModel);
 
 				sendIPCEvent('updateSiteStatus', site.id, initialSiteStatus);
 

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -1,6 +1,6 @@
 import { getServiceContainer, SiteData } from '@getflywheel/local/main';
-import type { Site, GenericObject, Providers } from '../types';
-import { HubOAuthProviders } from '../types';
+import type { Site, GenericObject, Providers, HubProviderRecord } from '../types';
+import { HubOAuthProviders, Providers as ProviderNames} from '../types';
 
 const serviceContainer = getServiceContainer().cradle;
 
@@ -44,6 +44,15 @@ export const providerToHubProvider = (provider: Providers) => {
 			return HubOAuthProviders.Google;
 		default:
 			return HubOAuthProviders.Dropbox;
+	}
+};
+
+export const hubProviderRecordToProvider = (provider: HubProviderRecord) => {
+	switch (provider.id) {
+		case 'google':
+			return ProviderNames.Drive;
+		default:
+			return ProviderNames.Dropbox;
 	}
 };
 

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -28,6 +28,9 @@ const withStoreProvider = (Component) => (props) => (
 export default function (context): void {
 	const { hooks } = context;
 	const SiteInfoToolsSectionHOC = withApolloProvider(withStoreProvider(SiteInfoToolsSection));
+	const ChooseCreateSiteHOC = withApolloProvider(withStoreProvider(ChooseCreateSite));
+	const SelectSiteBackupHOC = withApolloProvider(withStoreProvider(SelectSiteBackup));
+	const SelectSnapshotHOC = withApolloProvider(withStoreProvider(SelectSnapshot));
 
 	hooks.addFilter('siteInfoToolsItem', (items) => {
 		items.push({
@@ -57,9 +60,9 @@ export default function (context): void {
 		console.log(routes);
 
 		routes.push(
-			{ key: 'add-site-choose', path: `${path}/`, component: ChooseCreateSite },
-			{ key: 'add-site-select-site-backup', path: `${path}/select-site-backup`, component: SelectSiteBackup },
-			{ key: 'add-site-select-snapshot', path: `${path}/select-snapshot`, component: SelectSnapshot },
+			{ key: 'add-site-choose', path: `${path}/`, component: ChooseCreateSiteHOC },
+			{ key: 'add-site-select-site-backup', path: `${path}/select-site-backup`, component: SelectSiteBackupHOC },
+			{ key: 'add-site-select-snapshot', path: `${path}/select-snapshot`, component: SelectSnapshotHOC },
 		);
 
 		return routes;

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -60,6 +60,7 @@ export default function (context): void {
 		return statuses;
 	});
 
+	// add new routes and components to Local core
 	hooks.addFilter('AddSiteIndexJS:RoutesArray', (routes, path) => {
 		routes.forEach((route) => {
 			if (route.path === `${path}/`) {
@@ -76,6 +77,7 @@ export default function (context): void {
 		return routes;
 	});
 
+	// optionally modify NewSiteEnvironment component functionality in Local core
 	hooks.addFilter('AddSiteIndexJS:NewSiteEnvironment', (newSiteEnvironmentProps) => {
 		if (newSiteEnvironmentProps.siteSettings.cloudBackupMeta?.createdFromCloudBackup) {
 			const continueCreateSite = () => {
@@ -104,6 +106,7 @@ export default function (context): void {
 		return newSiteEnvironmentProps;
 	});
 
+	// add a new breadcrumbs stepper to the Add Site user flow
 	hooks.addFilter('AddSiteIndexJS:RenderBreadcrumbs', (breadcrumbsData) => {
 		const { localHistory, siteSettings } = breadcrumbsData;
 		const cloudBackupStepper = () => (
@@ -155,18 +158,25 @@ export default function (context): void {
 		return breadcrumbsData;
 	});
 
-	hooks.addFilter('AddSiteIndexJS:RenderCloseButton', (closeButtonData) => () => (
-		<CloseButtonHOC
-			onClose={closeButtonData.onCloseButton()}
-		/>
-	));
+	// modify the "close button" functionality for the Add Site user flow
+	hooks.addFilter('AddSiteIndexJS:RenderCloseButton', (closeButtonData) => {
+		closeButtonData.closeButton = () => (
+			<CloseButtonHOC
+				onClose={closeButtonData.onCloseButton()}
+			/>
+		);
 
+		return closeButtonData;
+	});
+
+	// add a "go back" button to the first step in the default Add Site user flow
 	hooks.addContent(
 		'NewSiteSite_AfterContent',
 		() => {
 			const goBack = () => {
 				LocalRenderer.sendIPCEvent('goToRoute', LOCAL_ROUTES.ADD_SITE_START);
 			};
+
 			return (
 				<TextButton
 					className="GoBack"

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -71,7 +71,7 @@ export default function (context): void {
 		routes.forEach((route) => {
 			if (route.path === `${path}/`) {
 				cloudBackupRoutes.push(
-					{ key: route.key, path: LOCAL_ROUTES.ADD_SITE_CREATE_NEW, component: route.component },
+					{ key: 'add-site-add', path: LOCAL_ROUTES.ADD_SITE_CREATE_NEW, component: route.component },
 				);
 			}
 			cloudBackupRoutes.push(route);

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -105,14 +105,13 @@ export default function (context): void {
 
 	hooks.addFilter('AddSiteIndexJS:RenderBreadcrumbs', (breadcrumbsData) => {
 		const { localHistory, siteSettings } = breadcrumbsData;
-
 		const cloudBackupStepper = () => (
 			<Stepper>
 				<Step
 					key={'choose-site'}
 					number={1}
-					done={localHistory.location.pathname !== '/main/add-site/'}
-					active={localHistory.location.pathname === '/main/add-site/'}
+					done={localHistory.location.pathname !== '/main/add-site/select-site-backup'}
+					active={localHistory.location.pathname === '/main/add-site/select-site-backup'}
 				>
 					Select Site
 				</Step>
@@ -140,8 +139,6 @@ export default function (context): void {
 				breadcrumbsData.defaultStepper = () => null;
 				break;
 			case '/main/add-site/select-site-backup':
-				breadcrumbsData.defaultStepper = () => cloudBackupStepper();
-				break;
 			case '/main/add-site/select-snapshot':
 				breadcrumbsData.defaultStepper = () => cloudBackupStepper();
 				break;
@@ -157,17 +154,11 @@ export default function (context): void {
 		return breadcrumbsData;
 	});
 
-	hooks.addFilter('AddSiteIndexJS:RenderCloseButton', (closeButtonData) => {
-		const closeButtonModified = () => (
-			<CloseButtonHOC
-				onClose={closeButtonData.onCloseButton()}
-			/>
-		);
-
-		closeButtonData.closeButton = () => closeButtonModified();
-
-		return closeButtonData;
-	});
+	hooks.addFilter('AddSiteIndexJS:RenderCloseButton', (closeButtonData) => () => (
+		<CloseButtonHOC
+			onClose={closeButtonData.onCloseButton()}
+		/>
+	));
 
 	hooks.addContent(
 		'NewSiteSite_AfterContent',

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -9,6 +9,7 @@ import { client } from './renderer/localClient/localGraphQLClient';
 import { ChooseCreateSite } from './renderer/components/multimachinebackups/ChooseCreateSite';
 import { SelectSiteBackup } from './renderer/components/multimachinebackups/SelectSiteBackup';
 import { SelectSnapshot } from './renderer/components/multimachinebackups/SelectSnapshot';
+import { CloseButtonWithStore } from './renderer/components/multimachinebackups/CloseButtonWithStore';
 import * as LocalRenderer from '@getflywheel/local/renderer';
 import {
 	Stepper,
@@ -37,6 +38,7 @@ export default function (context): void {
 	const ChooseCreateSiteHOC = withApolloProvider(withStoreProvider(ChooseCreateSite));
 	const SelectSiteBackupHOC = withApolloProvider(withStoreProvider(SelectSiteBackup));
 	const SelectSnapshotHOC = withApolloProvider(withStoreProvider(SelectSnapshot));
+	const CloseButtonHOC = withStoreProvider(CloseButtonWithStore);
 
 	hooks.addFilter('siteInfoToolsItem', (items) => {
 		items.push({
@@ -57,7 +59,7 @@ export default function (context): void {
 		return statuses;
 	});
 
-	hooks.addFilter('AddSiteUserFlow:RoutesArray', (routes, path) => {
+	hooks.addFilter('AddSiteIndexJS:RoutesArray', (routes, path) => {
 		routes.forEach((route) => {
 			if (route.path === `${path}/`) {
 				route.path = `${path}/add`;
@@ -73,7 +75,7 @@ export default function (context): void {
 		return routes;
 	});
 
-	hooks.addFilter('AddSiteUserFlow:NewSiteEnvironment', (newSiteEnvironmentProps) => {
+	hooks.addFilter('AddSiteIndexJS:NewSiteEnvironment', (newSiteEnvironmentProps) => {
 		if (newSiteEnvironmentProps.siteSettings.cloudBackupMeta?.createdFromCloudBackup) {
 			const continueCreateSite = () => {
 				LocalRenderer.sendIPCEvent('addSite', {
@@ -101,7 +103,7 @@ export default function (context): void {
 		return newSiteEnvironmentProps;
 	});
 
-	hooks.addFilter('AddSiteUserFlow:RenderBreadcrumbs', (breadcrumbsData) => {
+	hooks.addFilter('AddSiteIndexJS:RenderBreadcrumbs', (breadcrumbsData) => {
 		const { localHistory, siteSettings } = breadcrumbsData;
 
 		const cloudBackupStepper = () => (
@@ -153,6 +155,18 @@ export default function (context): void {
 		}
 
 		return breadcrumbsData;
+	});
+
+	hooks.addFilter('AddSiteIndexJS:RenderCloseButton', (closeButtonData) => {
+		const closeButtonModified = () => (
+			<CloseButtonHOC
+				onClose={closeButtonData.onCloseButton()}
+			/>
+		);
+
+		closeButtonData.closeButton = () => closeButtonModified();
+
+		return closeButtonData;
 	});
 
 	hooks.addContent(

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -93,13 +93,17 @@ export default function (context): void {
 			return newSiteEnvironmentProps;
 		}
 
+		newSiteEnvironmentProps.onGoBack = () => {
+			LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/add');
+		};
+
 		return newSiteEnvironmentProps;
 	});
 
 	hooks.addFilter('AddSiteUserFlow:RenderBreadcrumbs', (breadcrumbsData) => {
 		const { localHistory, siteSettings } = breadcrumbsData;
 
-		const newStepper = () => (
+		const cloudBackupStepper = () => (
 			<Stepper>
 				<Step
 					key={1}
@@ -133,10 +137,10 @@ export default function (context): void {
 				breadcrumbsData.defaultStepper = () => null;
 				break;
 			case '/main/add-site/select-site-backup':
-				breadcrumbsData.defaultStepper = () => newStepper();
+				breadcrumbsData.defaultStepper = () => cloudBackupStepper();
 				break;
 			case '/main/add-site/select-snapshot':
-				breadcrumbsData.defaultStepper = () => newStepper();
+				breadcrumbsData.defaultStepper = () => cloudBackupStepper();
 				break;
 		}
 
@@ -144,7 +148,7 @@ export default function (context): void {
 			siteSettings.cloudBackupMeta?.createdFromCloudBackup
 			&& localHistory.location.pathname === '/main/add-site/environment'
 		) {
-			breadcrumbsData.defaultStepper = () => newStepper();
+			breadcrumbsData.defaultStepper = () => cloudBackupStepper();
 		}
 
 		return breadcrumbsData;

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -16,6 +16,7 @@ import {
 	Step,
 	TextButton,
 } from '@getflywheel/local-components';
+import { LOCAL_ROUTES } from './constants';
 
 setupListeners();
 
@@ -62,14 +63,14 @@ export default function (context): void {
 	hooks.addFilter('AddSiteIndexJS:RoutesArray', (routes, path) => {
 		routes.forEach((route) => {
 			if (route.path === `${path}/`) {
-				route.path = `${path}/add`;
+				route.path = LOCAL_ROUTES.ADD_SITE_CREATE_NEW;
 			}
 		});
 
 		routes.push(
 			{ key: 'add-site-choose', path: `${path}/`, component: ChooseCreateSiteHOC },
-			{ key: 'add-site-select-site-backup', path: `${path}/select-site-backup`, component: SelectSiteBackupHOC },
-			{ key: 'add-site-select-snapshot', path: `${path}/select-snapshot`, component: SelectSnapshotHOC },
+			{ key: 'add-site-select-site-backup', path: LOCAL_ROUTES.ADD_SITE_BACKUP_SITE, component: SelectSiteBackupHOC },
+			{ key: 'add-site-select-snapshot', path: LOCAL_ROUTES.ADD_SITE_BACKUP_SNAPSHOT, component: SelectSnapshotHOC },
 		);
 
 		return routes;
@@ -86,7 +87,7 @@ export default function (context): void {
 			};
 
 			const onGoBack = () => {
-				LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/select-snapshot');
+				LocalRenderer.sendIPCEvent('goToRoute', LOCAL_ROUTES.ADD_SITE_BACKUP_SNAPSHOT);
 			};
 
 			newSiteEnvironmentProps.onContinue = continueCreateSite;
@@ -97,7 +98,7 @@ export default function (context): void {
 		}
 
 		newSiteEnvironmentProps.onGoBack = () => {
-			LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/add');
+			LocalRenderer.sendIPCEvent('goToRoute', LOCAL_ROUTES.ADD_SITE_CREATE_NEW);
 		};
 
 		return newSiteEnvironmentProps;
@@ -110,16 +111,16 @@ export default function (context): void {
 				<Step
 					key={'choose-site'}
 					number={1}
-					done={localHistory.location.pathname !== '/main/add-site/select-site-backup'}
-					active={localHistory.location.pathname === '/main/add-site/select-site-backup'}
+					done={localHistory.location.pathname !== LOCAL_ROUTES.ADD_SITE_BACKUP_SITE}
+					active={localHistory.location.pathname === LOCAL_ROUTES.ADD_SITE_BACKUP_SITE}
 				>
 					Select Site
 				</Step>
 				<Step
 					key={'choose-snapshot'}
 					number={2}
-					done={localHistory.location.pathname === '/main/add-site/environment'}
-					active={localHistory.location.pathname === '/main/add-site/select-snapshot'}
+					done={localHistory.location.pathname === LOCAL_ROUTES.ADD_SITE_ENVIRONMENT}
+					active={localHistory.location.pathname === LOCAL_ROUTES.ADD_SITE_BACKUP_SNAPSHOT}
 				>
 					Select Backup
 				</Step>
@@ -127,7 +128,7 @@ export default function (context): void {
 					key={'choose-environment'}
 					number={3}
 					done={false}
-					active={localHistory.location.pathname === '/main/add-site/environment'}
+					active={localHistory.location.pathname === LOCAL_ROUTES.ADD_SITE_ENVIRONMENT}
 				>
 					Setup Environment
 				</Step>
@@ -135,18 +136,18 @@ export default function (context): void {
 		);
 
 		switch (localHistory.location.pathname) {
-			case '/main/add-site':
+			case LOCAL_ROUTES.ADD_SITE_START:
 				breadcrumbsData.defaultStepper = () => null;
 				break;
-			case '/main/add-site/select-site-backup':
-			case '/main/add-site/select-snapshot':
+			case LOCAL_ROUTES.ADD_SITE_BACKUP_SITE:
+			case LOCAL_ROUTES.ADD_SITE_BACKUP_SNAPSHOT:
 				breadcrumbsData.defaultStepper = () => cloudBackupStepper();
 				break;
 		}
 
 		if (
 			siteSettings.cloudBackupMeta?.createdFromCloudBackup
-			&& localHistory.location.pathname === '/main/add-site/environment'
+			&& localHistory.location.pathname === LOCAL_ROUTES.ADD_SITE_ENVIRONMENT
 		) {
 			breadcrumbsData.defaultStepper = () => cloudBackupStepper();
 		}
@@ -164,7 +165,7 @@ export default function (context): void {
 		'NewSiteSite_AfterContent',
 		() => {
 			const goBack = () => {
-				LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site');
+				LocalRenderer.sendIPCEvent('goToRoute', LOCAL_ROUTES.ADD_SITE_START);
 			};
 			return (
 				<TextButton

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { ApolloProvider } from '@apollo/client';
 import { RestoreStates, BackupStates } from './types';
-import { store, useStoreSelector } from './renderer/store/store';
+import { store } from './renderer/store/store';
 import SiteInfoToolsSection from './renderer/components/siteinfotools/SiteInfoToolsSection';
 import { setupListeners } from './renderer/helpers/setupListeners';
 import { client } from './renderer/localClient/localGraphQLClient';
@@ -10,7 +10,6 @@ import { ChooseCreateSite } from './renderer/components/multimachinebackups/Choo
 import { SelectSiteBackup } from './renderer/components/multimachinebackups/SelectSiteBackup';
 import { SelectSnapshot } from './renderer/components/multimachinebackups/SelectSnapshot';
 import * as LocalRenderer from '@getflywheel/local/renderer';
-import { selectors } from './renderer/store/selectors';
 
 setupListeners();
 
@@ -70,20 +69,24 @@ export default function (context): void {
 	});
 
 	hooks.addFilter('AddSiteUserFlow:NewSiteEnvironment', (newSiteEnvironmentProps) => {
-		const continueCreateSite = () => {
-			LocalRenderer.sendIPCEvent('addSite', {
-				newSiteInfo: newSiteEnvironmentProps.siteSettings,
-				goToSite: true,
-				installWP: false,
-			});
-		};
+		if (newSiteEnvironmentProps.siteSettings.createdFromCloudBackup === true) {
+			const continueCreateSite = () => {
+				LocalRenderer.sendIPCEvent('addSite', {
+					newSiteInfo: newSiteEnvironmentProps.siteSettings,
+					goToSite: true,
+					installWP: false,
+				});
+			};
 
-		const onGoBack = () => {
-			LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/select-snapshot');
-		};
+			const onGoBack = () => {
+				LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/select-snapshot');
+			};
 
-		newSiteEnvironmentProps.onContinue = continueCreateSite;
-		newSiteEnvironmentProps.onGoBack = onGoBack;
+			newSiteEnvironmentProps.onContinue = continueCreateSite;
+			newSiteEnvironmentProps.onGoBack = onGoBack;
+
+			return newSiteEnvironmentProps;
+		}
 
 		return newSiteEnvironmentProps;
 	});

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -6,6 +6,9 @@ import { store } from './renderer/store/store';
 import SiteInfoToolsSection from './renderer/components/siteinfotools/SiteInfoToolsSection';
 import { setupListeners } from './renderer/helpers/setupListeners';
 import { client } from './renderer/localClient/localGraphQLClient';
+import { ChooseCreateSite } from './renderer/components/multimachinebackups/ChooseCreateSite';
+import { SelectSiteBackup } from './renderer/components/multimachinebackups/SelectSiteBackup';
+import { SelectSnapshot } from './renderer/components/multimachinebackups/SelectSnapshot';
 
 setupListeners();
 
@@ -43,5 +46,22 @@ export default function (context): void {
 		statuses.push(...Object.values(RestoreStates));
 		statuses.push(BackupStates.creatingDatabaseSnapshot);
 		return statuses;
+	});
+
+	hooks.addFilter('AddSiteUserFlow:RoutesArray', (routes, path) => {
+		routes.forEach((route) => {
+			if (route.path === `${path}/`) {
+				route.path = `${path}/add`;
+			}
+		});
+		console.log(routes);
+
+		routes.push(
+			{ key: 'add-site-choose', path: `${path}/`, component: ChooseCreateSite },
+			{ key: 'add-site-select-site-backup', path: `${path}/select-site-backup`, component: SelectSiteBackup },
+			{ key: 'add-site-select-snapshot', path: `${path}/select-snapshot`, component: SelectSnapshot },
+		);
+
+		return routes;
 	});
 }

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -42,22 +42,34 @@ export default function (context): void {
 	const CloseButtonHOC = withStoreProvider(CloseButtonWithStore);
 
 	hooks.addFilter('siteInfoToolsItem', (items) => {
-		items.push({
-			path: '/localBackups',
-			menuItem: 'Cloud Backups',
-			render: ({ site }) => (
-				<SiteInfoToolsSectionHOC site={site} />
-			),
+		const cloudBackupItems = [
+			{
+				path: '/localBackups',
+				menuItem: 'Cloud Backups',
+				render: ({ site }) => (
+					<SiteInfoToolsSectionHOC site={site} />
+				),
+			},
+		];
+
+		items.forEach((item) => {
+			cloudBackupItems.push(item);
 		});
 
-		return items;
+		return cloudBackupItems;
 	});
 
-	// todo - refactor to make use of this filter for backup statuses
 	hooks.addFilter('allowedSiteOverlayStatuses', (statuses: string[]) => {
-		statuses.push(...Object.values(RestoreStates));
-		statuses.push(BackupStates.creatingDatabaseSnapshot);
-		return statuses;
+		const cloudBackupStatuses: string[] = [
+			...Object.values(RestoreStates),
+			BackupStates.creatingDatabaseSnapshot,
+		];
+
+		statuses.forEach((status) => {
+			cloudBackupStatuses.push(status);
+		});
+
+		return cloudBackupStatuses;
 	});
 
 	// add new routes and components to Local core
@@ -98,7 +110,7 @@ export default function (context): void {
 			return {
 				...newSiteEnvironmentProps,
 				onContinue: continueCreateSite,
-				onGoBack: onGoBack,
+				onGoBack,
 				buttonText: 'Restore Site',
 			};
 		}
@@ -165,9 +177,7 @@ export default function (context): void {
 			};
 		}
 
-		return {
-			...breadcrumbsData,
-		};
+		return breadcrumbsData;
 	});
 
 	// modify the "close button" functionality for the Add Site user flow

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -69,7 +69,7 @@ export default function (context): void {
 	});
 
 	hooks.addFilter('AddSiteUserFlow:NewSiteEnvironment', (newSiteEnvironmentProps) => {
-		if (newSiteEnvironmentProps.siteSettings.createdFromCloudBackup === true) {
+		if (newSiteEnvironmentProps.siteSettings.cloudBackupMeta.createdFromCloudBackup === true) {
 			const continueCreateSite = () => {
 				LocalRenderer.sendIPCEvent('addSite', {
 					newSiteInfo: newSiteEnvironmentProps.siteSettings,

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -13,6 +13,7 @@ import * as LocalRenderer from '@getflywheel/local/renderer';
 import {
 	Stepper,
 	Step,
+	TextButton,
 } from '@getflywheel/local-components';
 
 setupListeners();
@@ -153,4 +154,21 @@ export default function (context): void {
 
 		return breadcrumbsData;
 	});
+
+	hooks.addContent(
+		'NewSiteSite_AfterContent',
+		() => {
+			const goBack = () => {
+				LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site');
+			};
+			return (
+				<TextButton
+					className="GoBack"
+					onClick={goBack}
+				>
+					Go Back
+				</TextButton>
+			);
+		},
+	);
 }

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -106,7 +106,7 @@ export default function (context): void {
 		const cloudBackupStepper = () => (
 			<Stepper>
 				<Step
-					key={1}
+					key={'choose-site'}
 					number={1}
 					done={localHistory.location.pathname !== '/main/add-site/'}
 					active={localHistory.location.pathname === '/main/add-site/'}
@@ -114,7 +114,7 @@ export default function (context): void {
 					Select Site
 				</Step>
 				<Step
-					key={2}
+					key={'choose-snapshot'}
 					number={2}
 					done={localHistory.location.pathname === '/main/add-site/environment'}
 					active={localHistory.location.pathname === '/main/add-site/select-snapshot'}
@@ -122,7 +122,7 @@ export default function (context): void {
 					Select Backup
 				</Step>
 				<Step
-					key={3}
+					key={'choose-environment'}
 					number={3}
 					done={false}
 					active={localHistory.location.pathname === '/main/add-site/environment'}

--- a/src/renderer/components/multimachinebackups/ChooseCreateSite.scss
+++ b/src/renderer/components/multimachinebackups/ChooseCreateSite.scss
@@ -1,0 +1,7 @@
+.radioBlock {
+	font-size: small;
+}
+
+.bannerContainer {
+	margin-top: 27px;
+}

--- a/src/renderer/components/multimachinebackups/ChooseCreateSite.scss
+++ b/src/renderer/components/multimachinebackups/ChooseCreateSite.scss
@@ -1,4 +1,16 @@
 .promoBanner {
 	margin-top: 50px;
 	border-radius: 4px;
+
+	span {
+		display: flex;
+	}
+}
+
+.radioBlock {
+	div > label {
+		display: flex !important;
+		flex-direction: column !important;
+		justify-content: center;
+	}
 }

--- a/src/renderer/components/multimachinebackups/ChooseCreateSite.scss
+++ b/src/renderer/components/multimachinebackups/ChooseCreateSite.scss
@@ -1,7 +1,3 @@
 .radioBlock {
 	font-size: small;
 }
-
-.bannerContainer {
-	margin-top: 27px;
-}

--- a/src/renderer/components/multimachinebackups/ChooseCreateSite.scss
+++ b/src/renderer/components/multimachinebackups/ChooseCreateSite.scss
@@ -14,3 +14,8 @@
 		justify-content: center;
 	}
 }
+
+.extraPadding {
+	padding-left: 15px;
+	padding-right: 15px;
+}

--- a/src/renderer/components/multimachinebackups/ChooseCreateSite.scss
+++ b/src/renderer/components/multimachinebackups/ChooseCreateSite.scss
@@ -1,3 +1,4 @@
-.radioBlock {
-	font-size: small;
+.promoBanner {
+	margin-top: 50px;
+	border-radius: 4px;
 }

--- a/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
+++ b/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
@@ -43,7 +43,7 @@ export const ChooseCreateSite = () => {
 		}
 
 		if (radioState === 'usebackup') {
-			store.dispatch(actions.getSitesList());
+			LocalRenderer.sendIPCEvent('goToRoute', LOCAL_ROUTES.ADD_SITE_BACKUP_SITE);
 		}
 	};
 
@@ -56,7 +56,7 @@ export const ChooseCreateSite = () => {
 		return (
 			<div className="AddSiteContent">
 				<div className="Inner">
-					<p>Authenticating connection and fetching sites...</p>
+					<p>Authenticating connection...</p>
 					<ProgressBar stripes />
 				</div>
 			</div>

--- a/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
+++ b/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
@@ -4,10 +4,13 @@ import {
 	RadioBlock,
 	Title,
 	ProgressBar,
+	Banner,
 } from '@getflywheel/local-components';
 import * as LocalRenderer from '@getflywheel/local/renderer';
 import { store, actions, useStoreSelector } from '../../store/store';
 import { selectors } from '../../store/selectors';
+import styles from './ChooseCreateSite.scss';
+import { ErrorBannerContainer } from './ErrorBannerContainer';
 
 export const ChooseCreateSite = () => {
 	const state = useStoreSelector(selectors.selectMultiMachineSliceState);
@@ -37,32 +40,36 @@ export const ChooseCreateSite = () => {
 	}
 
 	return (
-		<div className="AddSiteContent">
-			<Title size="l" container={{ margin: 'l 0' }}>Select the type of site you want to add</Title>
-			<div className="Inner">
-				<RadioBlock
-					onChange={(name) => setRadioState(name)}
-					default={radioState}
-					options={{
-						createnew: {
-							key: 'create-new-site',
-							label: 'Create a new site',
-						},
-						usebackup: {
-							key: 'use-cloud-backup',
-							label: 'Restore a site from Cloud Backups Add-on',
-							className: 'TID_NewSiteEnvironment_RadioBlockItem_Custom',
-						},
-					}}
-				/>
-				{}
+		<>
+			<ErrorBannerContainer />
+			<div className="AddSiteContent">
+				<Title size="l" container={{ margin: 'l 0' }}>Select the type of site you want to add</Title>
+				<div className="Inner">
+					<RadioBlock
+						className={styles.radioBlock}
+						onChange={(name) => setRadioState(name)}
+						default={radioState}
+						options={{
+							createnew: {
+								key: 'create-new-site',
+								label: 'Create a new site',
+							},
+							usebackup: {
+								key: 'use-cloud-backup',
+								label: 'Restore a site from Cloud Backups Add-on',
+								className: 'TID_NewSiteEnvironment_RadioBlockItem_Custom',
+							},
+						}}
+					/>
+					{}
+				</div>
+				<PrimaryButton
+					className="Continue"
+					onClick={onContinue}
+				>
+					Continue
+				</PrimaryButton>
 			</div>
-			<PrimaryButton
-				className="Continue"
-				onClick={onContinue}
-			>
-				Continue
-			</PrimaryButton>
-		</div>
+		</>
 	);
 };

--- a/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
+++ b/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
@@ -11,6 +11,7 @@ import { store, actions, useStoreSelector } from '../../store/store';
 import { selectors } from '../../store/selectors';
 import styles from './ChooseCreateSite.scss';
 import { ErrorBannerContainer } from './ErrorBannerContainer';
+import { LOCAL_ROUTES } from '../../../constants';
 
 export const ChooseCreateSite = () => {
 	const state = useStoreSelector(selectors.selectMultiMachineSliceState);
@@ -19,8 +20,7 @@ export const ChooseCreateSite = () => {
 
 	const onContinue = () => {
 		if (radioState === 'createnew') {
-			// todo - tyler - update all these routes to use constants within the addon
-			LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/add');
+			LocalRenderer.sendIPCEvent('goToRoute', LOCAL_ROUTES.ADD_SITE_CREATE_NEW);
 		}
 
 		if (radioState === 'usebackup') {

--- a/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
+++ b/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
@@ -28,6 +28,10 @@ export const ChooseCreateSite = () => {
 		}
 	};
 
+	const onPromoBannerDismiss = () => {
+		console.log('test');
+	}
+
 	if (isLoading) {
 		return (
 			<div className="AddSiteContent">
@@ -61,7 +65,14 @@ export const ChooseCreateSite = () => {
 							},
 						}}
 					/>
-					{}
+					<Banner
+						className={styles.promoBanner}
+						variant="neutral"
+						onDismiss={onPromoBannerDismiss}
+						icon="none"
+					>
+						<p>&#127881; You can now restore a site from a Cloud Backup! Select to restore a site to get started.</p>
+					</Banner>
 				</div>
 				<PrimaryButton
 					className="Continue"

--- a/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
+++ b/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import {
+	PrimaryButton,
+	RadioBlock,
+	TextButton,
+	Title,
+	FlySelect,
+	FlySelectOption,
+} from '@getflywheel/local-components';
+import * as LocalRenderer from '@getflywheel/local/renderer';
+
+// interface Props {
+
+// }
+
+export const ChooseCreateSite = () => {
+	const [radioState, setRadioState] = useState('createnew');
+
+	const onContinue = () => {
+		if (radioState === 'createnew') {
+			LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/add');
+		}
+
+		if (radioState === 'usebackup') {
+			LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/select-site-backup');
+		}
+	};
+
+	return (
+		<div className="AddSiteContent">
+			<Title size="l" container={{ margin: 'l 0' }}>Select the type of site you want to add</Title>
+			<div className="Inner">
+				<RadioBlock
+					onChange={(name) => setRadioState(name)}
+					default={radioState}
+					options={{
+						createnew: {
+							label: 'Create a new site',
+						},
+						usebackup: {
+							label: 'Restore a site from Cloud Backups Add-on',
+							className: 'TID_NewSiteEnvironment_RadioBlockItem_Custom',
+						},
+					}}
+				/>
+				{}
+			</div>
+			<PrimaryButton
+				className="TID_NewSiteEnvironment_Button_Continue Continue"
+				onClick={onContinue}
+			>
+				Continue
+			</PrimaryButton>
+		</div>
+	);
+};

--- a/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
+++ b/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
@@ -30,7 +30,7 @@ export const ChooseCreateSite = () => {
 		const getUserDataShowPromoBanner = async () => {
 			const showBanner = await LocalRenderer.ipcAsync(IPCASYNC_EVENTS.SHOULD_LOAD_PROMO_BANNER);
 
-			if (showBanner.show === true) {
+			if (showBanner && showBanner?.show === true) {
 				setShowBanner(true);
 			}
 		};
@@ -91,18 +91,21 @@ export const ChooseCreateSite = () => {
 											content={(
 												<div>
 													{noProvidersFound &&
-													<p>Uh oh! You don’t have a
+													<p className={styles.extraPadding}>
+														Uh oh!
 														<br/>
+														You don’t have a
 														storage provider
-														<br/>
 														connected to your account.
 													</p>}
 													{noConnectionToHub &&
-													<p>Uh oh! We couldn't connect
+													<p className={styles.extraPadding}>
+														Uh oh!
 														<br/>
+														We couldn't connect
 														to your Local account.
 													</p>}
-													<TextButton onClick={launchBrowserToHubBackups}>Manage providers</TextButton>
+													<TextButton onClick={launchBrowserToHubBackups}>Manage Account</TextButton>
 												</div>
 											)}
 											popperOffsetModifier={{ offset: [0, 12] }}

--- a/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
+++ b/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
@@ -2,29 +2,39 @@ import React, { useState } from 'react';
 import {
 	PrimaryButton,
 	RadioBlock,
-	TextButton,
 	Title,
-	FlySelect,
-	FlySelectOption,
+	ProgressBar,
 } from '@getflywheel/local-components';
 import * as LocalRenderer from '@getflywheel/local/renderer';
-
-// interface Props {
-
-// }
+import { store, actions, useStoreSelector } from '../../store/store';
+import { selectors } from '../../store/selectors';
 
 export const ChooseCreateSite = () => {
+	const state = useStoreSelector(selectors.selectMultiMachineSliceState);
+	const { isLoading } = state;
 	const [radioState, setRadioState] = useState('createnew');
 
 	const onContinue = () => {
 		if (radioState === 'createnew') {
+			// todo - tyler - update all these routes to use constants within the addon
 			LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/add');
 		}
 
 		if (radioState === 'usebackup') {
-			LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/select-site-backup');
+			store.dispatch(actions.getSitesList());
 		}
 	};
+
+	if (isLoading) {
+		return (
+			<div className="AddSiteContent">
+				<div className="Inner">
+					<p>Authenticating connection and fetching sites...</p>
+					<ProgressBar stripes />
+				</div>
+			</div>
+		);
+	}
 
 	return (
 		<div className="AddSiteContent">

--- a/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
+++ b/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
@@ -30,7 +30,7 @@ export const ChooseCreateSite = () => {
 
 	const onPromoBannerDismiss = () => {
 		console.log('test');
-	}
+	};
 
 	if (isLoading) {
 		return (

--- a/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
+++ b/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
@@ -45,9 +45,11 @@ export const ChooseCreateSite = () => {
 					default={radioState}
 					options={{
 						createnew: {
+							key: 'create-new-site',
 							label: 'Create a new site',
 						},
 						usebackup: {
+							key: 'use-cloud-backup',
 							label: 'Restore a site from Cloud Backups Add-on',
 							className: 'TID_NewSiteEnvironment_RadioBlockItem_Custom',
 						},

--- a/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
+++ b/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
@@ -46,7 +46,7 @@ export const ChooseCreateSite = () => {
 				{}
 			</div>
 			<PrimaryButton
-				className="TID_NewSiteEnvironment_Button_Continue Continue"
+				className="Continue"
 				onClick={onContinue}
 			>
 				Continue

--- a/src/renderer/components/multimachinebackups/CloseButtonWithStore.scss
+++ b/src/renderer/components/multimachinebackups/CloseButtonWithStore.scss
@@ -1,5 +1,5 @@
 .erroredState {
-	position: absolute;
+    position: absolute;
     z-index: 99;
     right: 30px;
     top: 100px !important;

--- a/src/renderer/components/multimachinebackups/CloseButtonWithStore.scss
+++ b/src/renderer/components/multimachinebackups/CloseButtonWithStore.scss
@@ -1,0 +1,6 @@
+.erroredState {
+	position: absolute;
+    z-index: 99;
+    right: 30px;
+    top: 100px !important;
+}

--- a/src/renderer/components/multimachinebackups/CloseButtonWithStore.tsx
+++ b/src/renderer/components/multimachinebackups/CloseButtonWithStore.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useStoreSelector } from '../../store/store';
+import { store, actions, useStoreSelector } from '../../store/store';
 import { selectors } from '../../store/selectors';
 import {
 	Close,
@@ -14,10 +14,15 @@ export const CloseButtonWithStore = (props: Props) => {
 	const state = useStoreSelector(selectors.selectMultiMachineSliceState);
 	const { isErrored } = state;
 
+	const handleClose = () => {
+		store.dispatch(actions.resetMultiMachineRestoreState());
+		props.onClose();
+	};
+
 	return (
 		<Close
 			className={isErrored && styles.erroredState}
-			onClick={props.onClose}
+			onClick={handleClose}
 		/>
 	);
 };

--- a/src/renderer/components/multimachinebackups/CloseButtonWithStore.tsx
+++ b/src/renderer/components/multimachinebackups/CloseButtonWithStore.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useStoreSelector } from '../../store/store';
+import { selectors } from '../../store/selectors';
+import {
+	Close,
+} from '@getflywheel/local-components';
+import styles from './CloseButtonWithStore.scss';
+
+interface Props {
+	onClose: () => void;
+}
+
+export const CloseButtonWithStore = (props: Props) => {
+	const state = useStoreSelector(selectors.selectMultiMachineSliceState);
+	const { isErrored } = state;
+
+	return (
+		<Close
+			className={isErrored && styles.erroredState}
+			onClick={props.onClose}
+		/>
+	);
+};

--- a/src/renderer/components/multimachinebackups/ErrorBannerContainer.scss
+++ b/src/renderer/components/multimachinebackups/ErrorBannerContainer.scss
@@ -1,0 +1,3 @@
+.bannerContainer {
+	margin-top: 27px;
+}

--- a/src/renderer/components/multimachinebackups/ErrorBannerContainer.tsx
+++ b/src/renderer/components/multimachinebackups/ErrorBannerContainer.tsx
@@ -2,15 +2,11 @@ import React from 'react';
 import {
 	Banner,
 } from '@getflywheel/local-components';
-import { useStoreSelector } from '../../store/store';
+import { store, actions, useStoreSelector } from '../../store/store';
 import { selectors } from '../../store/selectors';
 import styles from './ErrorBannerContainer.scss';
 import { SerializedError } from '@reduxjs/toolkit';
 import { MULTI_MACHINE_BACKUP_ERRORS } from '../../../constants';
-
-// interface Props {
-
-// }
 
 export const ErrorBannerContainer = () => {
 	const state = useStoreSelector(selectors.selectMultiMachineSliceState);
@@ -20,7 +16,7 @@ export const ErrorBannerContainer = () => {
 	if (!isErrored) {
 		return null;
 	}
-	console.log(activeError);
+
 	if (activeError) {
 		switch (activeError) {
 			case MULTI_MACHINE_BACKUP_ERRORS.NO_PROVIDERS_FOUND:
@@ -41,12 +37,19 @@ export const ErrorBannerContainer = () => {
 		}
 	}
 
-	// 'We could not fetch your sites. Please verify you're logged into your Local account and try again.'
-	// 'We could not authenticate your connection. Please verify you are logged into your account and try again.'
-	// 'There was an error retrieving your Cloud Backups. Please verify your account is connected to a storage provider and try again.'
+	const handleOnDismiss = () => {
+		store.dispatch(actions.setIsErrored(false));
+	};
+
 	return (
 		<div className={styles.bannerContainer}>
-			<Banner variant='error' icon='warning'>{bannerText}</Banner>
+			<Banner
+				variant='error'
+				icon='warning'
+				onDismiss={handleOnDismiss}
+			>
+				{bannerText}
+			</Banner>
 		</div>
 	);
 };

--- a/src/renderer/components/multimachinebackups/ErrorBannerContainer.tsx
+++ b/src/renderer/components/multimachinebackups/ErrorBannerContainer.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import {
+	Banner,
+} from '@getflywheel/local-components';
+import { useStoreSelector } from '../../store/store';
+import { selectors } from '../../store/selectors';
+import styles from './ErrorBannerContainer.scss';
+import { SerializedError } from '@reduxjs/toolkit';
+import { MULTI_MACHINE_BACKUP_ERRORS } from '../../../constants';
+
+// interface Props {
+
+// }
+
+export const ErrorBannerContainer = () => {
+	const state = useStoreSelector(selectors.selectMultiMachineSliceState);
+	const { isErrored, activeError } = state;
+	let bannerText = null as SerializedError;
+
+	if (!isErrored) {
+		return null;
+	}
+	console.log(activeError);
+	if (activeError) {
+		switch (activeError) {
+			case MULTI_MACHINE_BACKUP_ERRORS.NO_PROVIDERS_FOUND:
+				bannerText = activeError;
+				break;
+			case MULTI_MACHINE_BACKUP_ERRORS.NO_SITES_FOUND:
+				bannerText = activeError;
+				break;
+			case MULTI_MACHINE_BACKUP_ERRORS.NO_CONNECTED_PROVIDERS_FOR_SITE:
+				bannerText = activeError;
+				break;
+			case MULTI_MACHINE_BACKUP_ERRORS.NO_SNAPSHOTS_FOUND:
+				bannerText = activeError;
+				break;
+			default:
+				bannerText = 'We could not authenticate your connection. Please verify you are logged into your account and try again.' as SerializedError;
+				break;
+		}
+	}
+
+	// 'We could not fetch your sites. Please verify you're logged into your Local account and try again.'
+	// 'We could not authenticate your connection. Please verify you are logged into your account and try again.'
+	// 'There was an error retrieving your Cloud Backups. Please verify your account is connected to a storage provider and try again.'
+	return (
+		<div className={styles.bannerContainer}>
+			<Banner variant='error' icon='warning'>{bannerText}</Banner>
+		</div>
+	);
+};

--- a/src/renderer/components/multimachinebackups/ErrorBannerContainer.tsx
+++ b/src/renderer/components/multimachinebackups/ErrorBannerContainer.tsx
@@ -7,6 +7,7 @@ import { selectors } from '../../store/selectors';
 import styles from './ErrorBannerContainer.scss';
 import { SerializedError } from '@reduxjs/toolkit';
 import { MULTI_MACHINE_BACKUP_ERRORS } from '../../../constants';
+import { launchBrowserToHubBackups } from '../../helpers/launchBrowser';
 
 export const ErrorBannerContainer = () => {
 	const state = useStoreSelector(selectors.selectMultiMachineSliceState);
@@ -20,19 +21,13 @@ export const ErrorBannerContainer = () => {
 	if (activeError) {
 		switch (activeError) {
 			case MULTI_MACHINE_BACKUP_ERRORS.NO_PROVIDERS_FOUND:
-				bannerText = activeError;
-				break;
 			case MULTI_MACHINE_BACKUP_ERRORS.NO_SITES_FOUND:
-				bannerText = activeError;
-				break;
 			case MULTI_MACHINE_BACKUP_ERRORS.NO_CONNECTED_PROVIDERS_FOR_SITE:
-				bannerText = activeError;
-				break;
 			case MULTI_MACHINE_BACKUP_ERRORS.NO_SNAPSHOTS_FOUND:
 				bannerText = activeError;
 				break;
 			default:
-				bannerText = 'We could not authenticate your connection. Please verify you are logged into your account and try again.' as SerializedError;
+				bannerText = MULTI_MACHINE_BACKUP_ERRORS.GENERIC_HUB_CONNECTION_ERROR as SerializedError;
 				break;
 		}
 	}
@@ -47,6 +42,8 @@ export const ErrorBannerContainer = () => {
 				variant='error'
 				icon='warning'
 				onDismiss={handleOnDismiss}
+				buttonText='Go to account'
+				buttonOnClick={launchBrowserToHubBackups}
 			>
 				{bannerText}
 			</Banner>

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.scss
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.scss
@@ -14,3 +14,9 @@
 .headerPadding {
 	padding-bottom: 12px;
 }
+
+.tooltip {
+	position: absolute;
+	bottom: 30px;
+	right: 30px;
+}

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.scss
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.scss
@@ -1,0 +1,16 @@
+.innerContainer {
+	width: 644px;
+	align-self: center;
+	display: flex;
+	flex-grow: 1;
+	flex-direction: column;
+	justify-content: center;
+	align-items: left;
+	width: 50%;
+	min-width: 590px;
+	padding: 0 0 50px;
+}
+
+.headerPadding {
+	padding-bottom: 12px;
+}

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import shortid from 'shortid';
 import {
 	PrimaryButton,
@@ -14,7 +14,7 @@ import path from 'path';
 import { BackupSite, NewSiteInfoWithCloudMeta } from '../../../types';
 import { ErrorBannerContainer } from './ErrorBannerContainer';
 import styles from './SelectSiteBackup.scss';
-import { IPCASYNC_EVENTS, LOCAL_ROUTES } from '../../../constants';
+import { LOCAL_ROUTES } from '../../../constants';
 
 interface Props {
 	siteSettings: NewSiteInfoWithCloudMeta
@@ -31,6 +31,7 @@ export const SelectSiteBackup = (props: Props) => {
 
 	let flySelectSites: { [value: string]: string; } = {};
 
+	// create object required for select dropdown component
 	backupSites.forEach((site) => {
 		flySelectSites = {
 			...flySelectSites,
@@ -40,7 +41,6 @@ export const SelectSiteBackup = (props: Props) => {
 	});
 
 	const generateSiteSettingsData = (site: BackupSite) => {
-		// todo - tyler - check with design to see if we want to implement a site name field instead of generating a hash for uniqueness
 		const formattedSiteName = `${formatSiteNicename(site.name)}-${shortid.generate()}`;
 
 		const formattedSiteDomain = `${formattedSiteName}${defaultLocalSettings['new-site-defaults'].tld}`;
@@ -61,7 +61,6 @@ export const SelectSiteBackup = (props: Props) => {
 	const onSiteSelect = async (siteUUID: string) => {
 		const site: BackupSite = backupSites.find((site) => siteUUID === site.uuid);
 
-		// save site object to redux
 		store.dispatch(actions.setSelectedSite(site));
 
 		const newSiteSettings = generateSiteSettingsData(site);

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
@@ -14,7 +14,7 @@ import path from 'path';
 import { BackupSite, NewSiteInfoWithCloudMeta } from '../../../types';
 import { ErrorBannerContainer } from './ErrorBannerContainer';
 import styles from './SelectSiteBackup.scss';
-import { IPCASYNC_EVENTS } from '../../../constants';
+import { IPCASYNC_EVENTS, LOCAL_ROUTES } from '../../../constants';
 
 interface Props {
 	siteSettings: NewSiteInfoWithCloudMeta
@@ -82,8 +82,7 @@ export const SelectSiteBackup = (props: Props) => {
 
 	const onContinue = () => {
 		store.dispatch(actions.getSnapshotList());
-		// todo - tyler - replace route with constant
-		LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/select-snapshot');
+		LocalRenderer.sendIPCEvent('goToRoute', LOCAL_ROUTES.ADD_SITE_BACKUP_SNAPSHOT);
 	};
 
 	const onGoBack = () => {
@@ -91,7 +90,7 @@ export const SelectSiteBackup = (props: Props) => {
 
 		store.dispatch(actions.setSelectedSite(null));
 
-		LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site');
+		LocalRenderer.sendIPCEvent('goToRoute', LOCAL_ROUTES.ADD_SITE_START);
 	};
 
 	const continueDisabled = (selectedSite === null);

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import shortid from 'shortid';
 import {
 	PrimaryButton,
@@ -89,6 +89,8 @@ export const SelectSiteBackup = (props: Props) => {
 	const onGoBack = () => {
 		delete siteSettings.cloudBackupMeta;
 
+		store.dispatch(actions.setSelectedSite(null));
+
 		LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site');
 	};
 
@@ -108,6 +110,7 @@ export const SelectSiteBackup = (props: Props) => {
 								options={flySelectSites}
 								emptyPlaceholder="No backups available"
 								placeholder="Select a site"
+								value={selectedSite ? selectedSite.uuid : undefined}
 							/>
 						</div>
 					</div>

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
@@ -8,10 +8,10 @@ import {
 import { store, actions, useStoreSelector } from '../../store/store';
 import { selectors } from '../../store/selectors';
 import * as LocalRenderer from '@getflywheel/local/renderer';
-import * as Local from '@getflywheel/local';
 import path from 'path';
 import { BackupSite, NewSiteInfoWithCloudMeta } from '../../../types';
 import { ErrorBannerContainer } from './ErrorBannerContainer';
+import styles from './SelectSiteBackup.scss';
 
 interface Props {
 	siteSettings: NewSiteInfoWithCloudMeta
@@ -95,15 +95,18 @@ export const SelectSiteBackup = (props: Props) => {
 			<ErrorBannerContainer />
 			<div className="AddSiteContent">
 				<Title size="l" container={{ margin: 'l 0' }}>Select a site to restore</Title>
-				<div className="Inner">
-					<h3>Select a site with a Cloud Backup</h3>
-					<div className="FormField">
-						<FlySelect
-							onChange={(value) => onSiteSelect(value)}
-							options={flySelectSites}
-							emptyPlaceholder="No backups available"
-							placeholder="Select a site"
-						/>
+				<div className={styles.innerContainer}>
+					<h2 className={styles.headerPadding}>Select a site with a Cloud Backup</h2>
+					<div className="FormRow">
+						<div className="FormField">
+							<FlySelect
+								// className={styles.formField}
+								onChange={(value) => onSiteSelect(value)}
+								options={flySelectSites}
+								emptyPlaceholder="No backups available"
+								placeholder="Select a site"
+							/>
+						</div>
 					</div>
 				</div>
 				<PrimaryButton

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
@@ -77,6 +77,7 @@ export const SelectSiteBackup = (props: Props) => {
 			siteName: formattedSiteName,
 			siteDomain: formattedSiteDomain,
 			sitePath: formattedSitePath,
+			createdFromCloudBackup: true,
 		});
 	};
 

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import shortid from 'shortid';
 import {
 	PrimaryButton,
 	Title,
@@ -13,6 +14,7 @@ import path from 'path';
 import { BackupSite, NewSiteInfoWithCloudMeta } from '../../../types';
 import { ErrorBannerContainer } from './ErrorBannerContainer';
 import styles from './SelectSiteBackup.scss';
+import { IPCASYNC_EVENTS } from '../../../constants';
 
 interface Props {
 	siteSettings: NewSiteInfoWithCloudMeta
@@ -38,7 +40,8 @@ export const SelectSiteBackup = (props: Props) => {
 	});
 
 	const generateSiteSettingsData = (site: BackupSite) => {
-		const formattedSiteName = `${formatSiteNicename(site.name)}-clone`;
+		// todo - tyler - check with design to see if we want to implement a site name field instead of generating a hash for uniqueness
+		const formattedSiteName = `${formatSiteNicename(site.name)}-${shortid.generate()}`;
 
 		const formattedSiteDomain = `${formattedSiteName}${defaultLocalSettings['new-site-defaults'].tld}`;
 

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
@@ -3,16 +3,17 @@ import {
 	PrimaryButton,
 	Title,
 	FlySelect,
+	TextButton,
 } from '@getflywheel/local-components';
 import { store, actions, useStoreSelector } from '../../store/store';
 import { selectors } from '../../store/selectors';
 import * as LocalRenderer from '@getflywheel/local/renderer';
 import * as Local from '@getflywheel/local';
 import path from 'path';
-import { BackupSite } from '../../../types';
+import { BackupSite, NewSiteInfoWithCloudMeta } from '../../../types';
 
 interface Props {
-	siteSettings: Local.NewSiteInfo
+	siteSettings: NewSiteInfoWithCloudMeta
 	updateSiteSettings: (...any) => any
 	formatSiteNicename: (siteName: string) => string
 	defaultLocalSettings: any
@@ -80,6 +81,12 @@ export const SelectSiteBackup = (props: Props) => {
 		LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/select-snapshot');
 	};
 
+	const onGoBack = () => {
+		delete siteSettings.cloudBackupMeta;
+
+		LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site');
+	};
+
 	const continueDisabled = (selectedSite === null);
 
 	return (
@@ -103,6 +110,12 @@ export const SelectSiteBackup = (props: Props) => {
 			>
 				Continue
 			</PrimaryButton>
+			<TextButton
+				className="GoBack"
+				onClick={onGoBack}
+			>
+				Go Back
+			</TextButton>
 		</div>
 	);
 };

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
@@ -13,12 +13,20 @@ import { ipcAsync } from '@getflywheel/local/renderer';
 import { store, actions, useStoreSelector } from '../../store/store';
 import { selectors } from '../../store/selectors';
 import * as LocalRenderer from '@getflywheel/local/renderer';
+import * as Local from '@getflywheel/local';
+import path from 'path';
 
-// interface Props {
+interface Props {
+	siteSettings: Local.NewSiteInfo
+	updateSiteSettings: (...any) => any
+	formatSiteNicename: (siteName: string) => string
+	defaultLocalSettings: any
+	osPath: any
+}
 
-// }
+export const SelectSiteBackup = (props: Props) => {
+	const { updateSiteSettings, siteSettings, osPath, formatSiteNicename, defaultLocalSettings} = props;
 
-export const SelectSiteBackup = () => {
 	useEffect(() => {
 		const getSitesList = async () => {
 			const allSites = await ipcAsync(
@@ -36,9 +44,10 @@ export const SelectSiteBackup = () => {
 		getSitesList();
 	}, []);
 
-	let flySelectSites: { [value: string]: string; } = {};
-
 	const backupSites = useStoreSelector(selectors.selectAllBackupSites);
+	const selectedSite = useStoreSelector(selectors.selectBackupSite);
+
+	let flySelectSites: { [value: string]: string; } = {};
 
 	backupSites.forEach((site) => {
 		flySelectSites = {
@@ -48,29 +57,53 @@ export const SelectSiteBackup = () => {
 		return flySelectSites;
 	});
 
-	const onSiteSelect = (siteUUID: string) => {
-		// dispatch uuid value to redux store
-		store.dispatch(actions.setSelectedSite(siteUUID));
-		// set "disabled" prop on continue button to 'false'
+	const onSiteSelect = async (siteUUID: string) => {
+		const selectedSite = backupSites.find((site) => siteUUID === site.uuid);
+
+		store.dispatch(actions.setSelectedSite(selectedSite));
+
+		const formattedSiteName = `${formatSiteNicename(selectedSite.name)}-clone`;
+
+		const formattedSiteDomain = `${formattedSiteName}${defaultLocalSettings['new-site-defaults'].tld}`;
+
+		const sitePath = path.join(defaultLocalSettings['new-site-defaults'].sitesPath, formattedSiteName);
+
+		const formattedSitePath = osPath.addOSTrailingSlash(
+			osPath.toNative(sitePath),
+		);
+
+		updateSiteSettings({
+			...siteSettings,
+			siteName: formattedSiteName,
+			siteDomain: formattedSiteDomain,
+			sitePath: formattedSitePath,
+		});
 	};
 
 	const onContinue = () => {
 		LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/select-snapshot');
 	};
 
+	const continueDisabled = (selectedSite === null);
+
 	return (
-		<div>
+		<div className="AddSiteContent">
 			<Title size="l" container={{ margin: 'l 0' }}>Select a site to restore</Title>
 			<div className="Inner">
-				<p>Select a site with a Cloud Backup</p>
-				<FlySelect
-					onChange={(value) => onSiteSelect(value)}
-					options={flySelectSites}
-				/>
+				<h3>Select a site with a Cloud Backup</h3>
+				<div className="FormField">
+					<FlySelect
+						onChange={(value) => onSiteSelect(value)}
+						options={flySelectSites}
+						emptyPlaceholder="No backups available"
+						placeholder="Select a site"
+					/>
+				</div>
 			</div>
 			<PrimaryButton
 				className="Continue"
 				onClick={onContinue}
+				disabled={continueDisabled}
 			>
 				Continue
 			</PrimaryButton>

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
 	PrimaryButton,
 	RadioBlock,
@@ -6,12 +6,13 @@ import {
 	Title,
 	FlySelect,
 	FlySelectOption,
+	FlyDropdown,
 } from '@getflywheel/local-components';
 import { IPCASYNC_EVENTS } from '../../../constants';
 import { ipcAsync } from '@getflywheel/local/renderer';
 import { store, actions, useStoreSelector } from '../../store/store';
 import { selectors } from '../../store/selectors';
-
+import * as LocalRenderer from '@getflywheel/local/renderer';
 
 // interface Props {
 
@@ -20,22 +21,59 @@ import { selectors } from '../../store/selectors';
 export const SelectSiteBackup = () => {
 	useEffect(() => {
 		const getSitesList = async () => {
-			const bleeb = await ipcAsync(
+			const allSites = await ipcAsync(
 				IPCASYNC_EVENTS.GET_ALL_SITES,
 			);
 
-			store.dispatch(actions.setAllBackupSites(bleeb));
+			store.dispatch(actions.setAllBackupSites(allSites));
+
+			const availableProviders = await ipcAsync(
+				IPCASYNC_EVENTS.MULTI_MACHINE_GET_AVAILABLE_PROVIDERS,
+			);
+
+			store.dispatch(actions.setSelectedProvider(availableProviders[0].id));
 		};
 		getSitesList();
 	}, []);
 
+	let flySelectSites: { [value: string]: string; } = {};
+
 	const backupSites = useStoreSelector(selectors.selectAllBackupSites);
 
-	console.log(backupSites, 'tylers state');
+	backupSites.forEach((site) => {
+		flySelectSites = {
+			...flySelectSites,
+			[site.uuid]: site.name,
+		};
+		return flySelectSites;
+	});
+
+	const onSiteSelect = (siteUUID: string) => {
+		// dispatch uuid value to redux store
+		store.dispatch(actions.setSelectedSite(siteUUID));
+		// set "disabled" prop on continue button to 'false'
+	};
+
+	const onContinue = () => {
+		LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/select-snapshot');
+	};
 
 	return (
 		<div>
 			<Title size="l" container={{ margin: 'l 0' }}>Select a site to restore</Title>
+			<div className="Inner">
+				<p>Select a site with a Cloud Backup</p>
+				<FlySelect
+					onChange={(value) => onSiteSelect(value)}
+					options={flySelectSites}
+				/>
+			</div>
+			<PrimaryButton
+				className="Continue"
+				onClick={onContinue}
+			>
+				Continue
+			</PrimaryButton>
 		</div>
 	);
 };

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
@@ -4,6 +4,7 @@ import {
 	Title,
 	FlySelect,
 	TextButton,
+	Tooltip,
 } from '@getflywheel/local-components';
 import { store, actions, useStoreSelector } from '../../store/store';
 import { selectors } from '../../store/selectors';
@@ -100,7 +101,6 @@ export const SelectSiteBackup = (props: Props) => {
 					<div className="FormRow">
 						<div className="FormField">
 							<FlySelect
-								// className={styles.formField}
 								onChange={(value) => onSiteSelect(value)}
 								options={flySelectSites}
 								emptyPlaceholder="No backups available"
@@ -109,13 +109,37 @@ export const SelectSiteBackup = (props: Props) => {
 						</div>
 					</div>
 				</div>
-				<PrimaryButton
-					className="Continue"
-					onClick={onContinue}
-					disabled={continueDisabled}
-				>
-					Continue
-				</PrimaryButton>
+
+				{/* wrap button in tooltip if continue is disabled */}
+				{continueDisabled
+					?
+					<Tooltip
+						className={styles.tooltip}
+						content={(
+							<>
+								Please select a site before continuing.
+							</>
+						)}
+						popperOffsetModifier={{ offset: [0, 0] }}
+						position="top-start"
+					>
+						<PrimaryButton
+							className="Continue"
+							onClick={onContinue}
+							disabled={continueDisabled}
+						>
+						Continue
+						</PrimaryButton>
+					</Tooltip>
+					:
+					<PrimaryButton
+						className="Continue"
+						onClick={onContinue}
+						disabled={continueDisabled}
+					>
+						Continue
+					</PrimaryButton>
+				}
 				<TextButton
 					className="GoBack"
 					onClick={onGoBack}

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
@@ -77,7 +77,10 @@ export const SelectSiteBackup = (props: Props) => {
 			siteName: formattedSiteName,
 			siteDomain: formattedSiteDomain,
 			sitePath: formattedSitePath,
-			createdFromCloudBackup: true,
+			cloudBackupMeta: {
+				createdFromCloudBackup: true,
+				repoID: siteUUID,
+			},
 		});
 	};
 

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
@@ -9,6 +9,9 @@ import {
 } from '@getflywheel/local-components';
 import { IPCASYNC_EVENTS } from '../../../constants';
 import { ipcAsync } from '@getflywheel/local/renderer';
+import { store, actions, useStoreSelector } from '../../store/store';
+import { selectors } from '../../store/selectors';
+
 
 // interface Props {
 
@@ -20,10 +23,15 @@ export const SelectSiteBackup = () => {
 			const bleeb = await ipcAsync(
 				IPCASYNC_EVENTS.GET_ALL_SITES,
 			);
-			console.log(bleeb);
+
+			store.dispatch(actions.setAllBackupSites(bleeb));
 		};
 		getSitesList();
 	}, []);
+
+	const backupSites = useStoreSelector(selectors.selectAllBackupSites);
+
+	console.log(backupSites, 'tylers state');
 
 	return (
 		<div>

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import shortid from 'shortid';
 import {
 	PrimaryButton,
@@ -6,6 +6,7 @@ import {
 	FlySelect,
 	TextButton,
 	Tooltip,
+	ProgressBar,
 } from '@getflywheel/local-components';
 import { store, actions, useStoreSelector } from '../../store/store';
 import { selectors } from '../../store/selectors';
@@ -27,7 +28,11 @@ interface Props {
 export const SelectSiteBackup = (props: Props) => {
 	const { updateSiteSettings, siteSettings, osPath, formatSiteNicename, defaultLocalSettings } = props;
 	const state = useStoreSelector(selectors.selectMultiMachineSliceState);
-	const { backupSites, selectedSite } = state;
+	const { backupSites, selectedSite, isLoading } = state;
+
+	useEffect(() => {
+		store.dispatch(actions.getSitesList());
+	}, []);
 
 	let flySelectSites: { [value: string]: string; } = {};
 
@@ -93,6 +98,17 @@ export const SelectSiteBackup = (props: Props) => {
 	};
 
 	const continueDisabled = (selectedSite === null);
+
+	if (isLoading) {
+		return (
+			<div className="AddSiteContent">
+				<div className="Inner">
+					<p>Authenticating connection and fetching sites...</p>
+					<ProgressBar stripes />
+				</div>
+			</div>
+		);
+	}
 
 	return (
 		<>

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect } from 'react';
+import {
+	PrimaryButton,
+	RadioBlock,
+	TextButton,
+	Title,
+	FlySelect,
+	FlySelectOption,
+} from '@getflywheel/local-components';
+import { IPCASYNC_EVENTS } from '../../../constants';
+import { ipcAsync } from '@getflywheel/local/renderer';
+
+// interface Props {
+
+// }
+
+export const SelectSiteBackup = () => {
+	useEffect(() => {
+		const getSitesList = async () => {
+			const bleeb = await ipcAsync(
+				IPCASYNC_EVENTS.GET_ALL_SITES,
+			);
+			console.log(bleeb);
+		};
+		getSitesList();
+	}, []);
+
+	return (
+		<div>
+			<Title size="l" container={{ margin: 'l 0' }}>Select a site to restore</Title>
+		</div>
+	);
+};

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
@@ -11,6 +11,7 @@ import * as LocalRenderer from '@getflywheel/local/renderer';
 import * as Local from '@getflywheel/local';
 import path from 'path';
 import { BackupSite, NewSiteInfoWithCloudMeta } from '../../../types';
+import { ErrorBannerContainer } from './ErrorBannerContainer';
 
 interface Props {
 	siteSettings: NewSiteInfoWithCloudMeta
@@ -90,32 +91,35 @@ export const SelectSiteBackup = (props: Props) => {
 	const continueDisabled = (selectedSite === null);
 
 	return (
-		<div className="AddSiteContent">
-			<Title size="l" container={{ margin: 'l 0' }}>Select a site to restore</Title>
-			<div className="Inner">
-				<h3>Select a site with a Cloud Backup</h3>
-				<div className="FormField">
-					<FlySelect
-						onChange={(value) => onSiteSelect(value)}
-						options={flySelectSites}
-						emptyPlaceholder="No backups available"
-						placeholder="Select a site"
-					/>
+		<>
+			<ErrorBannerContainer />
+			<div className="AddSiteContent">
+				<Title size="l" container={{ margin: 'l 0' }}>Select a site to restore</Title>
+				<div className="Inner">
+					<h3>Select a site with a Cloud Backup</h3>
+					<div className="FormField">
+						<FlySelect
+							onChange={(value) => onSiteSelect(value)}
+							options={flySelectSites}
+							emptyPlaceholder="No backups available"
+							placeholder="Select a site"
+						/>
+					</div>
 				</div>
+				<PrimaryButton
+					className="Continue"
+					onClick={onContinue}
+					disabled={continueDisabled}
+				>
+					Continue
+				</PrimaryButton>
+				<TextButton
+					className="GoBack"
+					onClick={onGoBack}
+				>
+					Go Back
+				</TextButton>
 			</div>
-			<PrimaryButton
-				className="Continue"
-				onClick={onContinue}
-				disabled={continueDisabled}
-			>
-				Continue
-			</PrimaryButton>
-			<TextButton
-				className="GoBack"
-				onClick={onGoBack}
-			>
-				Go Back
-			</TextButton>
-		</div>
+		</>
 	);
 };

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.scss
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.scss
@@ -26,11 +26,15 @@
 .virtualTablePlaceholder {
 	height: 458px;
 	display: flex;
-	justify-content: center;
+	flex-direction: column;
+	align-items: center;
+	justify-content: space-between;
 	overflow-y: auto;
 }
 
 .loading {
+	margin-top: 100px;
+	justify-self: center;
 	align-self: center;
 }
 
@@ -91,4 +95,9 @@
 	position: absolute;
 	bottom: 30px;
 	right: 30px;
+}
+
+.loadMore {
+	margin-top: 30px;
+	justify-self: flex-end;
 }

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.scss
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.scss
@@ -26,7 +26,7 @@
 }
 
 .virtualTablePlaceholder {
-	height: 458px;
+	height: 398px;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
@@ -106,8 +106,29 @@
 
 .SnapshotsTableList_LoadingCont {
 	display: flex;
+	width: 100%;
 	height: 100%;
 	align-items: center;
-	margin-left: 55px;
+	justify-content: center;
 	@include theme-color-gray-else-gray25;
+}
+
+.faded {
+	opacity: 0.5;
+}
+
+.rowRenderer {
+	display: inherit;
+	flex-direction: inherit;
+	width: inherit;
+	height: inherit;
+	cursor: pointer;
+
+	div > div {
+		cursor: pointer;
+	}
+}
+
+.loadingMoreSnapshotsContainer {
+	height: 70px;
 }

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.scss
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.scss
@@ -86,3 +86,9 @@
 	  transform: scale(1);
 	}
 }
+
+.tooltip {
+	position: absolute;
+	bottom: 30px;
+	right: 30px;
+}

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.scss
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.scss
@@ -1,0 +1,88 @@
+.innerContainer {
+	width: 644px;
+	align-self: center;
+	display: flex;
+	flex-grow: 1;
+	flex-direction: column;
+	justify-content: center;
+	align-items: left;
+	width: 50%;
+	min-width: 590px;
+	padding: 0 0 50px;
+}
+
+.dropdownPadding {
+	padding-bottom: 20px;
+}
+
+.radioColumn {
+	flex: 0 0 50px;
+}
+
+.createdColumn {
+	flex: 0 0 150px;
+}
+
+.virtualTablePlaceholder {
+	height: 458px;
+	display: flex;
+	justify-content: center;
+	overflow-y: auto;
+}
+
+.loading {
+	align-self: center;
+}
+
+.noProviderState {
+	align-self: center;
+	color: #5D5E5E;
+}
+
+.radio {
+	font-size: 1.5rem;
+	color: #51bb7b;
+	display: grid;
+	grid-template-columns: min-content auto;
+	grid-gap: 0.5em;
+	cursor: pointer;
+}
+
+.radio__input {
+	display: flex;
+	justify-content: center;
+	input {
+		opacity: 0;
+		width: 0;
+		height: 0;
+	}
+}
+
+.radio__control {
+	display: block;
+	width: 1em;
+	height: 1em;
+	border-radius: 50%;
+	border: 1px solid currentColor;
+}
+
+.radio__before {
+	.radio__control {
+	  display: grid;
+	  place-items: center;
+	}
+
+	input + .radio__control::before {
+	  content: "";
+	  width: 7px;
+	  height: 7px;
+	  box-shadow: inset 6px 6px currentColor;
+	  border-radius: 50%;
+	  transition: 180ms transform ease-in-out;
+	  transform: scale(0);
+	}
+
+	input:checked + .radio__control::before {
+	  transform: scale(1);
+	}
+}

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.scss
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.scss
@@ -1,3 +1,5 @@
+@import '~@getflywheel/local-components/src/styles/_partials/index';
+
 .innerContainer {
 	width: 644px;
 	align-self: center;
@@ -100,4 +102,12 @@
 .loadMore {
 	margin-top: 30px;
 	justify-self: flex-end;
+}
+
+.SnapshotsTableList_LoadingCont {
+	display: flex;
+	height: 100%;
+	align-items: center;
+	margin-left: 55px;
+	@include theme-color-gray-else-gray25;
 }

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
@@ -188,15 +188,15 @@ export const SelectSnapshot = (props: Props) => {
 			<div className="AddSiteContent">
 				<Title size="l" container={{ margin: 'l 0' }}>Select a {selectedSite.name} Cloud Backup</Title>
 				<div className={secondStyles.innerContainer}>
-					<div className={secondStyles.dropdownPadding}>
+					{!isLoading && <div className={secondStyles.dropdownPadding}>
 						<ProviderDropdown
 							enabledProviders={individualSiteRepoProviders}
 							activeSiteProvider={selectedProvider}
 							multiMachineSelect={true}
 						/>
-					</div>
+					</div>}
 					<div className={secondStyles.virtualTablePlaceholder}>
-						{isLoading && <LoadingIndicator className={secondStyles.loading} dots={3}/>}
+						{isLoading && <LoadingIndicator big={true} className={secondStyles.loading} dots={3}/>}
 						{!isLoading && allSnapshots.length &&
 							<VirtualTable
 								className={virtualTableStyles.SnapshotsTableList_VirtualTable}

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
@@ -6,7 +6,7 @@ import {
 	IVirtualTableCellRendererDataArgs,
 	LoadingIndicator,
 	TextButton,
-	Banner,
+	Tooltip,
 } from '@getflywheel/local-components';
 import classnames from 'classnames';
 import { store, actions, useStoreSelector } from '../../store/store';
@@ -167,13 +167,37 @@ export const SelectSnapshot = (props: Props) => {
 						}
 					</div>
 				</div>
-				<PrimaryButton
-					className="Continue"
-					onClick={onContinue}
-					disabled={continueDisabled}
-				>
-					Continue
-				</PrimaryButton>
+
+				{/* wrap button in tooltip if continue is disabled */}
+				{continueDisabled
+					?
+					<Tooltip
+						className={secondStyles.tooltip}
+						content={(
+							<>
+								Please select a backup before continuing.
+							</>
+						)}
+						popperOffsetModifier={{ offset: [0, 0] }}
+						position="top-start"
+					>
+						<PrimaryButton
+							className="Continue"
+							onClick={onContinue}
+							disabled={continueDisabled}
+						>
+							Continue
+						</PrimaryButton>
+					</Tooltip>
+					:
+					<PrimaryButton
+						className="Continue"
+						onClick={onContinue}
+						disabled={continueDisabled}
+					>
+						Continue
+					</PrimaryButton>
+				}
 				<TextButton
 					className="GoBack"
 					onClick={onGoBack}

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
@@ -48,7 +48,7 @@ export const SelectSnapshot = (props: Props) => {
 	 */
 	const headers: React.ComponentProps<typeof VirtualTable>['headers'] = [
 		{ key: 'radioselect', value: '', className: secondStyles.radioColumn },
-		{ key: 'created_at', value: 'Created', className: secondStyles.createdColumn },
+		{ key: 'createdAt', value: 'Created', className: secondStyles.createdColumn },
 		{ key: 'configObject', value: 'Description' },
 	];
 
@@ -132,7 +132,7 @@ export const SelectSnapshot = (props: Props) => {
 
 		switch (colKey) {
 			case 'radioselect': return renderRadioButton(rowData);
-			case 'created_at': return renderDate(cellData);
+			case 'createdAt': return renderDate(cellData);
 			case 'configObject': return cellData.description;
 		}
 		return (

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+// interface Props {
+
+// }
+
+export const SelectSnapshot = () => {
+	return (
+		<div>
+			Hello World
+		</div>
+	);
+};

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
@@ -7,6 +7,7 @@ import {
 	LoadingIndicator,
 	TextButton,
 	Tooltip,
+	Button,
 } from '@getflywheel/local-components';
 import classnames from 'classnames';
 import { store, actions, useStoreSelector } from '../../store/store';
@@ -35,7 +36,8 @@ export const SelectSnapshot = (props: Props) => {
 		selectedSnapshot,
 		isLoading,
 		individualSiteRepoProviders,
-
+		currentSnapshotsPage,
+		totalSnapshotsPages,
 	} = state;
 
 	/**
@@ -46,6 +48,8 @@ export const SelectSnapshot = (props: Props) => {
 		{ key: 'created_at', value: 'Created', className: secondStyles.createdColumn },
 		{ key: 'configObject', value: 'Description' },
 	];
+
+	const hasMore = currentSnapshotsPage < totalSnapshotsPages;
 
 	const renderDate = (createdAt: string) => {
 		const [monDayYear, time] = DateUtils.formatDate(createdAt);
@@ -86,6 +90,10 @@ export const SelectSnapshot = (props: Props) => {
 		LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/select-site-backup');
 	};
 
+	const onClickLoadMore = () => {
+		store.dispatch(actions.requestSubsequentSnapshots());
+	};
+
 	const continueDisabled = (selectedSnapshot === null);
 
 	const renderRadioButton = (snapshot: BackupSnapshot) => (
@@ -117,8 +125,8 @@ export const SelectSnapshot = (props: Props) => {
 
 		switch (colKey) {
 			case 'radioselect': return renderRadioButton(rowData);
-			case 'configObject': return cellData.description;
 			case 'created_at': return renderDate(cellData);
+			case 'configObject': return cellData.description;
 		}
 		return (
 			<div>
@@ -141,9 +149,7 @@ export const SelectSnapshot = (props: Props) => {
 						/>
 					</div>
 					<div className={secondStyles.virtualTablePlaceholder}>
-						{isLoading &&
-							<LoadingIndicator className={secondStyles.loading} big={true} dots={3}/>
-						}
+						{isLoading && <LoadingIndicator className={secondStyles.loading} dots={3}/>}
 						{!isLoading && backupSnapshots.length &&
 							<VirtualTable
 								className={virtualTableStyles.SnapshotsTableList_VirtualTable}
@@ -160,6 +166,14 @@ export const SelectSnapshot = (props: Props) => {
 								rowHeaderHeightSize={'l'}
 							/>
 						}
+						{hasMore &&
+							<Button
+								className={secondStyles.loadMore}
+								onClick={onClickLoadMore}
+							>
+								Load more
+							</Button>
+						}
 						{!isLoading && !backupSnapshots.length &&
 							<div className={secondStyles.noProviderState}>
 								No storage provider connected.
@@ -167,7 +181,6 @@ export const SelectSnapshot = (props: Props) => {
 						}
 					</div>
 				</div>
-
 				{/* wrap button in tooltip if continue is disabled */}
 				{continueDisabled
 					?

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
@@ -21,6 +21,7 @@ import styles from '../siteinfotools/SiteInfoToolsSection.scss';
 import secondStyles from './SelectSnapshot.scss';
 import virtualTableStyles from '../siteinfotools/SnapshotsTableList.scss';
 import { LOCAL_ROUTES } from '../../../constants';
+import { selectMultiMachineActiveSiteSnapshots } from '../../store/multiMachineRestoreSlice';
 
 interface Props {
 	updateSiteSettings: any
@@ -30,10 +31,10 @@ interface Props {
 export const SelectSnapshot = (props: Props) => {
 	const { updateSiteSettings, siteSettings } = props;
 	const state = useStoreSelector(selectors.selectMultiMachineSliceState);
+	const allSnapshots = useStoreSelector(selectMultiMachineActiveSiteSnapshots);
 	const {
 		selectedProvider,
 		selectedSite,
-		backupSnapshots,
 		selectedSnapshot,
 		isLoading,
 		individualSiteRepoProviders,
@@ -41,6 +42,7 @@ export const SelectSnapshot = (props: Props) => {
 		totalSnapshotsPages,
 	} = state;
 
+	console.log('snapshots: ', allSnapshots);
 	/**
 	 * The columns defined in order and with the intended header text.
 	 */
@@ -69,7 +71,7 @@ export const SelectSnapshot = (props: Props) => {
 
 	const onRadioChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 		const snapshotHash = event.currentTarget.value;
-		const selectedSnapshot = backupSnapshots.find((snapshot) => snapshotHash === snapshot.hash);
+		const selectedSnapshot = allSnapshots.find((snapshot) => snapshotHash === snapshot.hash);
 		store.dispatch(actions.setSelectedSnapshot(selectedSnapshot));
 
 		updateSiteSettings({
@@ -155,11 +157,11 @@ export const SelectSnapshot = (props: Props) => {
 					</div>
 					<div className={secondStyles.virtualTablePlaceholder}>
 						{isLoading && <LoadingIndicator className={secondStyles.loading} dots={3}/>}
-						{!isLoading && backupSnapshots.length &&
+						{!isLoading && allSnapshots.length &&
 							<VirtualTable
 								className={virtualTableStyles.SnapshotsTableList_VirtualTable}
 								cellRenderer={renderCell}
-								data={backupSnapshots}
+								data={allSnapshots}
 								extraData={{
 									selectedSite,
 									selectedProvider,
@@ -179,7 +181,7 @@ export const SelectSnapshot = (props: Props) => {
 								Load more
 							</Button>
 						}
-						{!isLoading && !backupSnapshots.length &&
+						{!isLoading && !allSnapshots.length &&
 							<div className={secondStyles.noProviderState}>
 								No storage provider connected.
 							</div>

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
@@ -6,6 +6,7 @@ import {
 	IVirtualTableCellRendererDataArgs,
 	LoadingIndicator,
 	TextButton,
+	Banner,
 } from '@getflywheel/local-components';
 import { store, actions, useStoreSelector } from '../../store/store';
 import { selectors } from '../../store/selectors';
@@ -14,6 +15,7 @@ import type { BackupSnapshot } from '../../../types';
 import DateUtils from '../../helpers/DateUtils';
 import styles from '../siteinfotools/SiteInfoToolsSection.scss';
 import { ProviderDropdown } from '../siteinfotools/ProviderDropdown';
+import { ErrorBannerContainer } from './ErrorBannerContainer';
 
 
 interface Props {
@@ -126,41 +128,44 @@ export const SelectSnapshot = (props: Props) => {
 	}
 
 	return (
-		<div className="AddSiteContent">
-			<Title size="l" container={{ margin: 'l 0' }}>Select a {selectedSite.name} Cloud Backup</Title>
-			<div className="Inner">
-				<ProviderDropdown
-					enabledProviders={individualSiteRepoProviders}
-					activeSiteProvider={selectedProvider}
-					multiMachineSelect={true}
-				/>
-				<VirtualTable
-					cellRenderer={renderCell}
-					data={backupSnapshots}
-					extraData={{
-						selectedSite,
-						selectedProvider,
-					}}
-					headers={headers}
-					headersCapitalize={'none'}
-					headersWeight={500}
-					rowHeightSize={70}
-					rowHeaderHeightSize={'l'}
-				/>
+		<>
+			<ErrorBannerContainer />
+			<div className="AddSiteContent">
+				<Title size="l" container={{ margin: 'l 0' }}>Select a {selectedSite.name} Cloud Backup</Title>
+				<div className="Inner">
+					<ProviderDropdown
+						enabledProviders={individualSiteRepoProviders}
+						activeSiteProvider={selectedProvider}
+						multiMachineSelect={true}
+					/>
+					<VirtualTable
+						cellRenderer={renderCell}
+						data={backupSnapshots}
+						extraData={{
+							selectedSite,
+							selectedProvider,
+						}}
+						headers={headers}
+						headersCapitalize={'none'}
+						headersWeight={500}
+						rowHeightSize={70}
+						rowHeaderHeightSize={'l'}
+					/>
+				</div>
+				<PrimaryButton
+					className="Continue"
+					onClick={onContinue}
+					disabled={continueDisabled}
+				>
+					Continue
+				</PrimaryButton>
+				<TextButton
+					className="GoBack"
+					onClick={onGoBack}
+				>
+					Go Back
+				</TextButton>
 			</div>
-			<PrimaryButton
-				className="Continue"
-				onClick={onContinue}
-				disabled={continueDisabled}
-			>
-				Continue
-			</PrimaryButton>
-			<TextButton
-				className="GoBack"
-				onClick={onGoBack}
-			>
-				Go Back
-			</TextButton>
-		</div>
+		</>
 	);
 };

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
@@ -20,6 +20,7 @@ import { ErrorBannerContainer } from './ErrorBannerContainer';
 import styles from '../siteinfotools/SiteInfoToolsSection.scss';
 import secondStyles from './SelectSnapshot.scss';
 import virtualTableStyles from '../siteinfotools/SnapshotsTableList.scss';
+import { LOCAL_ROUTES } from '../../../constants';
 
 interface Props {
 	updateSiteSettings: any
@@ -83,14 +84,14 @@ export const SelectSnapshot = (props: Props) => {
 	};
 
 	const onContinue = () => {
-		LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/environment');
+		LocalRenderer.sendIPCEvent('goToRoute', LOCAL_ROUTES.ADD_SITE_ENVIRONMENT);
 	};
 
 	const onGoBack = () => {
 		store.dispatch(actions.setSelectedSnapshot(null));
 		store.dispatch(actions.setSelectedProvider(null));
 
-		LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/select-site-backup');
+		LocalRenderer.sendIPCEvent('goToRoute', LOCAL_ROUTES.ADD_SITE_BACKUP_SITE);
 	};
 
 	const onClickLoadMore = () => {

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
@@ -1,4 +1,4 @@
-import React, {useRef} from 'react';
+import React, { useRef } from 'react';
 import {
 	PrimaryButton,
 	Title,
@@ -7,7 +7,6 @@ import {
 	LoadingIndicator,
 	TextButton,
 	Tooltip,
-	Button,
 } from '@getflywheel/local-components';
 import classnames from 'classnames';
 import { store, actions, useStoreSelector } from '../../store/store';
@@ -17,15 +16,16 @@ import type { BackupSnapshot } from '../../../types';
 import DateUtils from '../../helpers/DateUtils';
 import { ProviderDropdown } from '../siteinfotools/ProviderDropdown';
 import { ErrorBannerContainer } from './ErrorBannerContainer';
-import styles from '../siteinfotools/SiteInfoToolsSection.scss';
-import secondStyles from './SelectSnapshot.scss';
-import virtualTableStyles from '../siteinfotools/SnapshotsTableList.scss';
 import { LOCAL_ROUTES } from '../../../constants';
 import {
 	selectMultiMachineActiveSiteSnapshots,
 	MULTI_MACHINE_SNAPSHOTS_HAS_MORE,
 } from '../../store/multiMachineRestoreSlice';
 import useOnScreen from '../../helpers/useOnScreen';
+
+import styles from './SelectSnapshot.scss';
+import siteInfoToolsStyles from '../siteinfotools/SiteInfoToolsSection.scss';
+import virtualTableStyles from '../siteinfotools/SnapshotsTableList.scss';
 
 interface Props {
 	updateSiteSettings: any
@@ -53,10 +53,10 @@ export const SelectSnapshot = (props: Props) => {
 	 */
 	const headers: React.ComponentProps<typeof VirtualTable>['headers'] = [
 		{ key: 'radioselect', value: '', className: classnames(
-			secondStyles.radioColumn,
+			styles.radioColumn,
 		) },
 		{ key: 'createdAt', value: 'Created', className: classnames(
-			secondStyles.createdColumn,
+			styles.createdColumn,
 		) },
 		{ key: 'configObject', value: 'Description' },
 	];
@@ -67,10 +67,10 @@ export const SelectSnapshot = (props: Props) => {
 		const [monDayYear, time] = DateUtils.formatDate(createdAt);
 		return (
 			<div className={classnames(
-				secondStyles.createdColumn,
-				styles.SnapshotsTableList_DateCell,
+				styles.createdColumn,
+				siteInfoToolsStyles.SnapshotsTableList_DateCell,
 				(!rowSelected)
-					? secondStyles.faded
+					? styles.faded
 					: undefined
 			)}>
 				<div className={virtualTableStyles.SnapshotsTableList_DateCell_MonDayYear}>
@@ -113,45 +113,46 @@ export const SelectSnapshot = (props: Props) => {
 	const continueDisabled = (selectedSnapshot === null);
 
 	const renderRadioButton = (snapshot: BackupSnapshot) => (
-		<div className={secondStyles.radioColumn}>
+		<div className={styles.radioColumn}>
 			<label className={classnames(
-				secondStyles.radio,
-				secondStyles.radio__before,
+				styles.radio,
+				styles.radio__before,
 			)}>
-				<span className={secondStyles.radio__input}>
+				<span className={styles.radio__input}>
 					<input
 						type='radio'
 						name='snapshotSelect'
 						value={snapshot.hash}
 						checked={selectedSnapshot ? selectedSnapshot.hash === snapshot.hash : false}
 					/>
-					<span className={secondStyles.radio__control}></span>
+					<span className={styles.radio__control}></span>
 				</span>
-				<span className={secondStyles.radio__label}></span>
+				<span className={styles.radio__label}></span>
 			</label>
 		</div>
 	);
+
 
 	const LoadMoreWhenVisibleCell = () => {
 		const ref = useRef();
 		const isVisible = useOnScreen(ref);
 
 		if (isVisible && hasMore && !isLoading && !isErrored) {
-			// asynchronous get snapshots given the site and provider
 			store.dispatch(actions.requestSubsequentSnapshots());
 		}
 
 		return (
 			<div
 				ref={ref}
-				className={secondStyles.SnapshotsTableList_LoadingCont}
+				className={styles.SnapshotsTableList_LoadingCont}
 			/>
 		);
 	};
 
+	// wrap each row in a click event handler that will save snapshot to state
 	const renderRow = (dataArgs: IVirtualTableCellRendererDataArgs) => (
 		<div
-			className={secondStyles.rowRenderer}
+			className={styles.rowRenderer}
 			onClick={() => onRowSelect(dataArgs)}
 		>
 			{ dataArgs.children }
@@ -168,6 +169,7 @@ export const SelectSnapshot = (props: Props) => {
 			return cellData;
 		}
 
+		// responsible for the "auto load more snapshots" functionality
 		if (snapshot.hash === MULTI_MACHINE_SNAPSHOTS_HAS_MORE) {
 			// don't render any cells other than the middle description/configObject one
 			if (colKey !== 'createdAt') {
@@ -184,7 +186,7 @@ export const SelectSnapshot = (props: Props) => {
 				return (
 					<div className={
 						(!rowSelected)
-							? secondStyles.faded
+							? styles.faded
 							: undefined
 					}>
 						{cellData.description}
@@ -203,16 +205,18 @@ export const SelectSnapshot = (props: Props) => {
 			<ErrorBannerContainer />
 			<div className="AddSiteContent">
 				<Title size="l" container={{ margin: 'l 0' }}>Select a {selectedSite?.name} Cloud Backup</Title>
-				<div className={secondStyles.innerContainer}>
-					{!isLoading && <div className={secondStyles.dropdownPadding}>
+				<div className={styles.innerContainer}>
+
+					{!isLoading && <div className={styles.dropdownPadding}>
 						<ProviderDropdown
 							enabledProviders={individualSiteRepoProviders}
 							activeSiteProvider={selectedProvider}
 							multiMachineSelect={true}
 						/>
 					</div>}
-					<div className={secondStyles.virtualTablePlaceholder}>
-						{isLoading && <LoadingIndicator big={true} className={secondStyles.loading} dots={3}/>}
+
+					<div className={styles.virtualTablePlaceholder}>
+						{isLoading && <LoadingIndicator big={true} className={styles.loading} dots={3}/>}
 						{!isLoading && allSnapshots.length &&
 							<VirtualTable
 								className={virtualTableStyles.SnapshotsTableList_VirtualTable}
@@ -232,22 +236,24 @@ export const SelectSnapshot = (props: Props) => {
 							/>
 						}
 						{!isLoading && !allSnapshots.length &&
-							<div className={secondStyles.noProviderState}>
+							<div className={styles.noProviderState}>
 								No storage provider connected.
 							</div>
 						}
 					</div>
-					<div className={secondStyles.loadingMoreSnapshotsContainer}>
-						<div className={secondStyles.SnapshotsTableList_LoadingCont}>
+
+					<div className={styles.loadingMoreSnapshotsContainer}>
+						<div className={styles.SnapshotsTableList_LoadingCont}>
 							{isLoadingMoreSnapshots && <LoadingIndicator dots={3} />}
 						</div>
 					</div>
+
 				</div>
 				{/* wrap button in tooltip if continue is disabled */}
 				{continueDisabled
 					?
 					<Tooltip
-						className={secondStyles.tooltip}
+						className={styles.tooltip}
 						content={(
 							<>
 								Please select a backup before continuing.

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
@@ -5,6 +5,7 @@ import {
 	VirtualTable,
 	IVirtualTableCellRendererDataArgs,
 	LoadingIndicator,
+	TextButton,
 } from '@getflywheel/local-components';
 import { store, actions, useStoreSelector } from '../../store/store';
 import { selectors } from '../../store/selectors';
@@ -32,7 +33,6 @@ export const SelectSnapshot = (props: Props) => {
 		individualSiteRepoProviders,
 
 	} = state;
-	console.log(state);
 
 	/**
 	 * The columns defined in order and with the intended header text.
@@ -76,6 +76,10 @@ export const SelectSnapshot = (props: Props) => {
 
 	const onContinue = () => {
 		LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/environment');
+	};
+
+	const onGoBack = () => {
+		LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/select-site-backup');
 	};
 
 	const continueDisabled = (selectedSnapshot === null);
@@ -151,6 +155,12 @@ export const SelectSnapshot = (props: Props) => {
 			>
 				Continue
 			</PrimaryButton>
+			<TextButton
+				className="GoBack"
+				onClick={onGoBack}
+			>
+				Go Back
+			</TextButton>
 		</div>
 	);
 };

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
@@ -12,6 +12,7 @@ import * as LocalRenderer from '@getflywheel/local/renderer';
 import type { BackupSnapshot } from '../../../types';
 import DateUtils from '../../helpers/DateUtils';
 import styles from '../siteinfotools/SiteInfoToolsSection.scss';
+import { ProviderDropdown } from '../siteinfotools/ProviderDropdown';
 
 
 interface Props {
@@ -22,7 +23,16 @@ interface Props {
 export const SelectSnapshot = (props: Props) => {
 	const { updateSiteSettings, siteSettings } = props;
 	const state = useStoreSelector(selectors.selectMultiMachineSliceState);
-	const { selectedProvider, selectedSite, backupSnapshots, selectedSnapshot, isLoading } = state;
+	const {
+		selectedProvider,
+		selectedSite,
+		backupSnapshots,
+		selectedSnapshot,
+		isLoading,
+		individualSiteRepoProviders,
+
+	} = state;
+	console.log(state);
 
 	/**
 	 * The columns defined in order and with the intended header text.
@@ -115,6 +125,11 @@ export const SelectSnapshot = (props: Props) => {
 		<div className="AddSiteContent">
 			<Title size="l" container={{ margin: 'l 0' }}>Select a {selectedSite.name} Cloud Backup</Title>
 			<div className="Inner">
+				<ProviderDropdown
+					enabledProviders={individualSiteRepoProviders}
+					activeSiteProvider={selectedProvider}
+					multiMachineSelect={true}
+				/>
 				<VirtualTable
 					cellRenderer={renderCell}
 					data={backupSnapshots}

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
@@ -1,10 +1,43 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { IPCASYNC_EVENTS } from '../../../constants';
+import { ipcAsync } from '@getflywheel/local/renderer';
+import {
+	PrimaryButton,
+	RadioBlock,
+	TextButton,
+	Title,
+	FlySelect,
+	FlySelectOption,
+	FlyDropdown,
+} from '@getflywheel/local-components';
+import { store, actions, useStoreSelector } from '../../store/store';
+import { selectors } from '../../store/selectors';
+import * as LocalRenderer from '@getflywheel/local/renderer';
+
 
 // interface Props {
 
 // }
 
 export const SelectSnapshot = () => {
+	const selectedProvider = useStoreSelector(selectors.selectEnabledProvider);
+	const selectedBackupSite = useStoreSelector(selectors.selectBackupSite);
+
+	useEffect(() => {
+		const getSnapshotsList = async () => {
+			if (selectedProvider && selectedBackupSite) {
+				const allSnapshots = await ipcAsync(
+					IPCASYNC_EVENTS.GET_ALL_SNAPSHOTS,
+					selectedBackupSite,
+					selectedProvider,
+				);
+
+				store.dispatch(actions.setBackupSnapshots(allSnapshots.snapshots));
+			}
+		};
+		getSnapshotsList();
+	}, []);
+
 	return (
 		<div>
 			Hello World

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
@@ -8,15 +8,17 @@ import {
 	TextButton,
 	Banner,
 } from '@getflywheel/local-components';
+import classnames from 'classnames';
 import { store, actions, useStoreSelector } from '../../store/store';
 import { selectors } from '../../store/selectors';
 import * as LocalRenderer from '@getflywheel/local/renderer';
 import type { BackupSnapshot } from '../../../types';
 import DateUtils from '../../helpers/DateUtils';
-import styles from '../siteinfotools/SiteInfoToolsSection.scss';
 import { ProviderDropdown } from '../siteinfotools/ProviderDropdown';
 import { ErrorBannerContainer } from './ErrorBannerContainer';
-
+import styles from '../siteinfotools/SiteInfoToolsSection.scss';
+import secondStyles from './SelectSnapshot.scss';
+import virtualTableStyles from '../siteinfotools/SnapshotsTableList.scss';
 
 interface Props {
 	updateSiteSettings: any
@@ -40,8 +42,8 @@ export const SelectSnapshot = (props: Props) => {
 	 * The columns defined in order and with the intended header text.
 	 */
 	const headers: React.ComponentProps<typeof VirtualTable>['headers'] = [
-		{ key: 'radioselect', value: '' },
-		{ key: 'created_at', value: 'Created' },
+		{ key: 'radioselect', value: '', className: secondStyles.radioColumn },
+		{ key: 'created_at', value: 'Created', className: secondStyles.createdColumn },
 		{ key: 'configObject', value: 'Description' },
 	];
 
@@ -50,7 +52,7 @@ export const SelectSnapshot = (props: Props) => {
 
 		return (
 			<div className={styles.SnapshotsTableList_DateCell}>
-				<div className={styles.SnapshotsTableList_DateCell_MonDayYear}>
+				<div className={virtualTableStyles.SnapshotsTableList_DateCell_MonDayYear}>
 					{ monDayYear }
 				</div>
 				<div>
@@ -87,13 +89,22 @@ export const SelectSnapshot = (props: Props) => {
 	const continueDisabled = (selectedSnapshot === null);
 
 	const renderRadioButton = (snapshot: BackupSnapshot) => (
-		<div >
-			<input
-				type='radio'
-				name='snapshotSelect'
-				value={snapshot.hash}
-				onChange={(value) => onRadioChange(value)}
-			/>
+		<div>
+			<label className={classnames(
+				secondStyles.radio,
+				secondStyles.radio__before,
+			)}>
+				<span className={secondStyles.radio__input}>
+					<input
+						type='radio'
+						name='snapshotSelect'
+						value={snapshot.hash}
+						onChange={(value) => onRadioChange(value)}
+					/>
+					<span className={secondStyles.radio__control}></span>
+				</span>
+				<span className={secondStyles.radio__label}></span>
+			</label>
 		</div>
 	);
 
@@ -109,7 +120,6 @@ export const SelectSnapshot = (props: Props) => {
 			case 'configObject': return cellData.description;
 			case 'created_at': return renderDate(cellData);
 		}
-
 		return (
 			<div>
 				{ dataArgs.cellData }
@@ -117,40 +127,45 @@ export const SelectSnapshot = (props: Props) => {
 		);
 	};
 
-	if (isLoading) {
-		return (
-			<div className="AddSiteContent">
-				<div className="Inner">
-					<LoadingIndicator big={true} dots={3}/>
-				</div>
-			</div>
-		);
-	}
-
 	return (
 		<>
 			<ErrorBannerContainer />
 			<div className="AddSiteContent">
 				<Title size="l" container={{ margin: 'l 0' }}>Select a {selectedSite.name} Cloud Backup</Title>
-				<div className="Inner">
-					<ProviderDropdown
-						enabledProviders={individualSiteRepoProviders}
-						activeSiteProvider={selectedProvider}
-						multiMachineSelect={true}
-					/>
-					<VirtualTable
-						cellRenderer={renderCell}
-						data={backupSnapshots}
-						extraData={{
-							selectedSite,
-							selectedProvider,
-						}}
-						headers={headers}
-						headersCapitalize={'none'}
-						headersWeight={500}
-						rowHeightSize={70}
-						rowHeaderHeightSize={'l'}
-					/>
+				<div className={secondStyles.innerContainer}>
+					<div className={secondStyles.dropdownPadding}>
+						<ProviderDropdown
+							enabledProviders={individualSiteRepoProviders}
+							activeSiteProvider={selectedProvider}
+							multiMachineSelect={true}
+						/>
+					</div>
+					<div className={secondStyles.virtualTablePlaceholder}>
+						{isLoading &&
+							<LoadingIndicator className={secondStyles.loading} big={true} dots={3}/>
+						}
+						{!isLoading && backupSnapshots.length &&
+							<VirtualTable
+								className={virtualTableStyles.SnapshotsTableList_VirtualTable}
+								cellRenderer={renderCell}
+								data={backupSnapshots}
+								extraData={{
+									selectedSite,
+									selectedProvider,
+								}}
+								headers={headers}
+								headersCapitalize={'none'}
+								headersWeight={500}
+								rowHeightSize={70}
+								rowHeaderHeightSize={'l'}
+							/>
+						}
+						{!isLoading && !backupSnapshots.length &&
+							<div className={secondStyles.noProviderState}>
+								No storage provider connected.
+							</div>
+						}
+					</div>
 				</div>
 				<PrimaryButton
 					className="Continue"

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
@@ -15,17 +15,18 @@ import {
 import { store, actions, useStoreSelector } from '../../store/store';
 import { selectors } from '../../store/selectors';
 import * as LocalRenderer from '@getflywheel/local/renderer';
-import type { BackupSnapshot, HubProviderRecord } from '../../../types';
+import type { BackupSnapshot, Providers } from '../../../types';
 import DateUtils from '../../helpers/DateUtils';
 import styles from '../siteinfotools/SiteInfoToolsSection.scss';
 
 
-// interface Props {
-// 	updateSiteSettings: any
-// 	siteSettings: any
-// }
+interface Props {
+	updateSiteSettings: any
+	siteSettings: any
+}
 
-export const SelectSnapshot = () => {
+export const SelectSnapshot = (props: Props) => {
+	const { updateSiteSettings, siteSettings } = props;
 	const selectedProvider = useStoreSelector(selectors.selectEnabledProvider);
 	const selectedBackupSite = useStoreSelector(selectors.selectBackupSite);
 	const backupSnapshots = useStoreSelector(selectors.selectAllSnapshots);
@@ -74,6 +75,16 @@ export const SelectSnapshot = () => {
 		const snapshotHash = event.currentTarget.value;
 		const selectedSnapshot = backupSnapshots.find((snapshot) => snapshotHash === snapshot.hash);
 		store.dispatch(actions.setSelectedSnapshot(selectedSnapshot));
+
+		updateSiteSettings({
+			...siteSettings,
+			cloudBackupMeta: {
+				...siteSettings.cloudBackupMeta,
+				createdFromCloudBackup: true,
+				snapshotID: snapshotHash,
+				provider: selectedProvider,
+			},
+		});
 	};
 
 	const onContinue = () => {

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
@@ -87,6 +87,9 @@ export const SelectSnapshot = (props: Props) => {
 	};
 
 	const onGoBack = () => {
+		store.dispatch(actions.setSelectedSnapshot(null));
+		store.dispatch(actions.setSelectedProvider(null));
+
 		LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/select-site-backup');
 	};
 
@@ -108,6 +111,7 @@ export const SelectSnapshot = (props: Props) => {
 						name='snapshotSelect'
 						value={snapshot.hash}
 						onChange={(value) => onRadioChange(value)}
+						checked={selectedSnapshot ? selectedSnapshot.hash === snapshot.hash : false}
 					/>
 					<span className={secondStyles.radio__control}></span>
 				</span>

--- a/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSnapshot.tsx
@@ -9,26 +9,34 @@ import {
 	FlySelect,
 	FlySelectOption,
 	FlyDropdown,
+	VirtualTable,
+	IVirtualTableCellRendererDataArgs,
 } from '@getflywheel/local-components';
 import { store, actions, useStoreSelector } from '../../store/store';
 import { selectors } from '../../store/selectors';
 import * as LocalRenderer from '@getflywheel/local/renderer';
+import type { BackupSnapshot, HubProviderRecord } from '../../../types';
+import DateUtils from '../../helpers/DateUtils';
+import styles from '../siteinfotools/SiteInfoToolsSection.scss';
 
 
 // interface Props {
-
+// 	updateSiteSettings: any
+// 	siteSettings: any
 // }
 
 export const SelectSnapshot = () => {
 	const selectedProvider = useStoreSelector(selectors.selectEnabledProvider);
 	const selectedBackupSite = useStoreSelector(selectors.selectBackupSite);
+	const backupSnapshots = useStoreSelector(selectors.selectAllSnapshots);
+	const selectedSnapshot = useStoreSelector(selectors.selectActiveSnapshot);
 
 	useEffect(() => {
 		const getSnapshotsList = async () => {
 			if (selectedProvider && selectedBackupSite) {
 				const allSnapshots = await ipcAsync(
 					IPCASYNC_EVENTS.GET_ALL_SNAPSHOTS,
-					selectedBackupSite,
+					selectedBackupSite.uuid,
 					selectedProvider,
 				);
 
@@ -38,9 +46,98 @@ export const SelectSnapshot = () => {
 		getSnapshotsList();
 	}, []);
 
+	/**
+	 * The columns defined in order and with the intended header text.
+	 */
+	const headers: React.ComponentProps<typeof VirtualTable>['headers'] = [
+		{ key: 'radioselect', value: '' },
+		{ key: 'created_at', value: 'Created' },
+		{ key: 'configObject', value: 'Description' },
+	];
+
+	const renderDate = (createdAt: string) => {
+		const [monDayYear, time] = DateUtils.formatDate(createdAt);
+
+		return (
+			<div className={styles.SnapshotsTableList_DateCell}>
+				<div className={styles.SnapshotsTableList_DateCell_MonDayYear}>
+					{ monDayYear }
+				</div>
+				<div>
+					{ time }
+				</div>
+			</div>
+		);
+	};
+
+	const onRadioChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+		const snapshotHash = event.currentTarget.value;
+		const selectedSnapshot = backupSnapshots.find((snapshot) => snapshotHash === snapshot.hash);
+		store.dispatch(actions.setSelectedSnapshot(selectedSnapshot));
+	};
+
+	const onContinue = () => {
+		LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/environment');
+	};
+
+	const continueDisabled = (selectedSnapshot === null);
+
+	const renderRadioButton = (snapshot: BackupSnapshot) => (
+		<div >
+			<input
+				type='radio'
+				name='snapshotSelect'
+				value={snapshot.hash}
+				onChange={(value) => onRadioChange(value)}
+			/>
+		</div>
+	);
+
+	const renderCell = (dataArgs: IVirtualTableCellRendererDataArgs) => {
+		const { colKey, cellData, isHeader, rowData } = dataArgs;
+
+		if (isHeader) {
+			return cellData;
+		}
+
+		switch (colKey) {
+			case 'radioselect': return renderRadioButton(rowData);
+			case 'configObject': return cellData.description;
+			case 'created_at': return renderDate(cellData);
+		}
+
+		return (
+			<div>
+				{ dataArgs.cellData }
+			</div>
+		);
+	};
+
 	return (
-		<div>
-			Hello World
+		<div className="AddSiteContent">
+			<Title size="l" container={{ margin: 'l 0' }}>Select a {selectedBackupSite.name} Cloud Backup</Title>
+			<div className="Inner">
+				<VirtualTable
+					cellRenderer={renderCell}
+					data={backupSnapshots}
+					extraData={{
+						selectedBackupSite,
+						selectedProvider,
+					}}
+					headers={headers}
+					headersCapitalize={'none'}
+					headersWeight={500}
+					rowHeightSize={70}
+					rowHeaderHeightSize={'l'}
+				/>
+			</div>
+			<PrimaryButton
+				className="Continue"
+				onClick={onContinue}
+				disabled={continueDisabled}
+			>
+				Continue
+			</PrimaryButton>
 		</div>
 	);
 };

--- a/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
+++ b/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
@@ -260,7 +260,7 @@ export const SnapshotsTableList = ({ site }: Props) => {
 	const {
 		isLoadingEnabledProviders,
 	} = useStoreSelector((state) => state.providers);
-
+	console.log('tylers snapshot log', snapshotsPlusBackingupPlaceholder);
 	if ((activePagingDetails?.isLoading && activePagingDetails.offset === 1) ||
 		isLoadingEnabledProviders
 	) {

--- a/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
+++ b/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
@@ -260,7 +260,7 @@ export const SnapshotsTableList = ({ site }: Props) => {
 	const {
 		isLoadingEnabledProviders,
 	} = useStoreSelector((state) => state.providers);
-	console.log('tylers snapshot log', snapshotsPlusBackingupPlaceholder);
+
 	if ((activePagingDetails?.isLoading && activePagingDetails.offset === 1) ||
 		isLoadingEnabledProviders
 	) {

--- a/src/renderer/components/siteinfotools/ToolsHeader.tsx
+++ b/src/renderer/components/siteinfotools/ToolsHeader.tsx
@@ -3,10 +3,13 @@ import styles from './ToolsHeader.scss';
 import type { Site } from '@getflywheel/local';
 import { ProviderDropdown } from './ProviderDropdown';
 import { PrimaryButton } from '@getflywheel/local-components';
-import { useStoreSelector } from '../../store/store';
 import { launchBrowserToHubBackups } from '../../helpers/launchBrowser';
 import { StartBackupButton } from './StartBackupButton';
 import { RefreshButton } from './RefreshButton';
+import { selectors } from '../../store/selectors';
+import {
+	useStoreSelector,
+} from '../../store/store';
 
 interface Props {
 	site: Site;
@@ -15,10 +18,16 @@ interface Props {
 export const ToolsHeader = (props: Props) => {
 	const { site } = props;
 	const { enabledProviders } = useStoreSelector((state) => state.providers);
+	const activeSiteProvider = useStoreSelector(selectors.selectActiveProvider);
 
 	return (
 		<div className={styles.ToolsHeaders}>
-			<ProviderDropdown />
+			<ProviderDropdown
+				enabledProviders={enabledProviders}
+				activeSiteProvider={activeSiteProvider}
+				multiMachineSelect={false}
+				siteId={site.id}
+			/>
 			<div className={styles.ToolsHeaders_Right}>
 				<RefreshButton />
 				{enabledProviders?.length

--- a/src/renderer/store/multiMachineRestoreSlice.ts
+++ b/src/renderer/store/multiMachineRestoreSlice.ts
@@ -37,6 +37,7 @@ export const multiMachineRestoreSlice = createSlice({
 		isLoading: false,
 		isLoadingMoreSnapshots: false,
 		isErrored: false,
+		providerIsErrored: false,
 		activeError: null as SerializedError,
 		currentSnapshotsPage: null as number,
 		totalSnapshotsPages: null as number,
@@ -56,6 +57,14 @@ export const multiMachineRestoreSlice = createSlice({
 		},
 		setIsErrored: (state, action) => {
 			state.isErrored = action.payload;
+			return state;
+		},
+		setProviderIsErrored: (state, action) => {
+			state.providerIsErrored = action.payload;
+			return state;
+		},
+		setActiveError: (state, action) => {
+			state.activeError = action.payload;
 			return state;
 		},
 	},
@@ -83,7 +92,7 @@ export const multiMachineRestoreSlice = createSlice({
 			})
 			.addCase(getProvidersList.rejected, (state, action) => {
 				state.isLoading = false;
-				state.isErrored = true;
+				state.providerIsErrored = true;
 				state.activeError = action.payload;
 			})
 			// getSnapshotList cases

--- a/src/renderer/store/multiMachineRestoreSlice.ts
+++ b/src/renderer/store/multiMachineRestoreSlice.ts
@@ -30,6 +30,10 @@ export const multiMachineRestoreSlice = createSlice({
 			state.selectedSnapshot = action.payload;
 			return state;
 		},
+		setIsErrored: (state, action) => {
+			state.isErrored = action.payload;
+			return state;
+		},
 	},
 	extraReducers: (builder) => {
 		builder

--- a/src/renderer/store/multiMachineRestoreSlice.ts
+++ b/src/renderer/store/multiMachineRestoreSlice.ts
@@ -13,8 +13,8 @@ import { AppState } from './store';
 
 const snapshotsEntityAdapter = createEntityAdapter<BackupSnapshot>({
 	selectId: (snapshot) => snapshot.id,
-	// regardless of the order received, do this additional sort by descending updated date/time
-	sortComparer: (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+	// regardless of the order received, do this additional sort by descending created date/time
+	sortComparer: (a, b) => (new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
 });
 
 
@@ -109,9 +109,7 @@ export const multiMachineRestoreSlice = createSlice({
 				state.isLoading = true;
 			})
 			.addCase(requestSubsequentSnapshots.fulfilled, (state, action) => {
-				action.payload.snapshots.snapshots.forEach(
-					(snapshot: BackupSnapshot) => state.backupSnapshots.push(snapshot),
-				);
+				snapshotsEntityAdapter.upsertMany(state.backupSnapshots, action.payload.snapshots.snapshots);
 				state.isLoading = false;
 				state.currentSnapshotsPage = action.payload.snapshots.pagination.currentPage;
 				state.totalSnapshotsPages = action.payload.snapshots.pagination.lastPage;

--- a/src/renderer/store/multiMachineRestoreSlice.ts
+++ b/src/renderer/store/multiMachineRestoreSlice.ts
@@ -18,7 +18,6 @@ const snapshotsEntityAdapter = createEntityAdapter<BackupSnapshot>({
 	sortComparer: (a, b) => (new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()),
 });
 
-export const LOADING_MULTI_MACHINE_SNAPSHOTS = 'paging_is_loading_multi_machine_snapshots';
 export const MULTI_MACHINE_SNAPSHOTS_HAS_MORE = 'paging_has_more_multi_machine_snapshots';
 
 /**
@@ -27,20 +26,27 @@ export const MULTI_MACHINE_SNAPSHOTS_HAS_MORE = 'paging_has_more_multi_machine_s
 export const multiMachineRestoreSlice = createSlice({
 	name: 'multiMachineRestore',
 	initialState: {
+		// sites
 		backupSites: [] as BackupSite[],
-		backupSnapshots: snapshotsEntityAdapter.getInitialState(),
-		backupProviders: [] as HubProviderRecord[],
-		individualSiteRepoProviders: [] as HubProviderRecord[],
 		selectedSite: null as BackupSite,
+
+		// snapshots
+		backupSnapshots: snapshotsEntityAdapter.getInitialState(),
 		selectedSnapshot: null as BackupSnapshot,
-		selectedProvider: null as HubProviderRecord,
-		isLoading: false,
 		isLoadingMoreSnapshots: false,
-		isErrored: false,
-		providerIsErrored: false,
-		activeError: null as SerializedError,
 		currentSnapshotsPage: null as number,
 		totalSnapshotsPages: null as number,
+
+		//providers
+		backupProviders: [] as HubProviderRecord[],
+		individualSiteRepoProviders: [] as HubProviderRecord[],
+		selectedProvider: null as HubProviderRecord,
+		providerIsErrored: false,
+
+		// general
+		isLoading: false,
+		isErrored: false,
+		activeError: null as SerializedError,
 	},
 	reducers: {
 		resetMultiMachineRestoreState: (state) => {
@@ -175,6 +181,8 @@ export const selectMultiMachineActiveSiteSnapshots = createSelector(
 	) => {
 		const hasMore = currentSnapshotsPage < totalSnapshotsPages;
 
+		// if hub returns multiple pages of snapshots
+		// append a blank snapshot object with a unique hash to indicate this fact
 		return [
 			...selectAll,
 			...(hasMore && !isLoading && !isLoadingMoreSnapshots

--- a/src/renderer/store/multiMachineRestoreSlice.ts
+++ b/src/renderer/store/multiMachineRestoreSlice.ts
@@ -37,6 +37,10 @@ export const multiMachineRestoreSlice = createSlice({
 			state.selectedSnapshot = action.payload;
 			return state;
 		},
+		setSelectedProvider: (state, action) => {
+			state.selectedSnapshot = action.payload;
+			return state;
+		},
 		setIsErrored: (state, action) => {
 			state.isErrored = action.payload;
 			return state;

--- a/src/renderer/store/multiMachineRestoreSlice.ts
+++ b/src/renderer/store/multiMachineRestoreSlice.ts
@@ -1,7 +1,8 @@
 import {
 	createSlice,
 } from '@reduxjs/toolkit';
-import type { BackupSite, BackupSnapshot, HubOAuthProviders } from '../../types';
+import type { BackupSite, BackupSnapshot, HubOAuthProviders, HubProviderRecord } from '../../types';
+import { getSitesList, getSnapshotList } from './multiMachineThunks';
 
 /**
  * State for the active site.
@@ -11,19 +12,14 @@ export const multiMachineRestoreSlice = createSlice({
 	initialState: {
 		backupSites: [] as BackupSite[],
 		backupSnapshots: [] as BackupSnapshot[],
+		backupProviders: [] as HubProviderRecord[],
+		individualSiteRepoProviders: [] as HubProviderRecord[],
 		selectedSite: null as BackupSite,
 		selectedSnapshot: null as BackupSnapshot,
 		selectedProvider: null as HubOAuthProviders,
+		isLoading: false,
 	},
 	reducers: {
-		setAllBackupSites: (state, action) => {
-			state.backupSites = action.payload;
-			return state;
-		},
-		setBackupSnapshots: (state, action) => {
-			state.backupSnapshots = action.payload;
-			return state;
-		},
 		setSelectedSite: (state, action) => {
 			state.selectedSite = action.payload;
 			return state;
@@ -32,9 +28,31 @@ export const multiMachineRestoreSlice = createSlice({
 			state.selectedSnapshot = action.payload;
 			return state;
 		},
-		setSelectedProvider: (state, action) => {
-			state.selectedProvider = action.payload;
-			return state;
-		},
+	},
+	extraReducers: (builder) => {
+		builder
+			.addCase(getSitesList.pending, (state) => {
+				state.isLoading = true;
+			})
+			.addCase(getSitesList.fulfilled, (state, action) => {
+				state.isLoading = false;
+				state.backupProviders = action.payload.availableProviders;
+				state.backupSites = action.payload.allSites;
+			})
+			.addCase(getSitesList.rejected, (state) => {
+				state.isLoading = false;
+			})
+			.addCase(getSnapshotList.pending, (state) => {
+				state.isLoading = true;
+			})
+			.addCase(getSnapshotList.fulfilled, (state, action) => {
+				state.isLoading = false;
+				state.backupSnapshots = action.payload.snapshots.snapshots;
+				state.individualSiteRepoProviders = action.payload.individualSiteProviders;
+				state.selectedProvider = action.payload.individualSiteProviders[0];
+			})
+			.addCase(getSnapshotList.rejected, (state) => {
+				state.isLoading = false;
+			});
 	},
 });

--- a/src/renderer/store/multiMachineRestoreSlice.ts
+++ b/src/renderer/store/multiMachineRestoreSlice.ts
@@ -11,7 +11,7 @@ export const multiMachineRestoreSlice = createSlice({
 	initialState: {
 		backupSites: [] as BackupSite[],
 		backupSnapshots: [] as BackupSnapshot[],
-		selectedSite: null as string,
+		selectedSite: null as BackupSite,
 		selectedSnapshot: null as BackupSnapshot,
 		selectedProvider: null as HubOAuthProviders,
 	},

--- a/src/renderer/store/multiMachineRestoreSlice.ts
+++ b/src/renderer/store/multiMachineRestoreSlice.ts
@@ -43,6 +43,14 @@ export const multiMachineRestoreSlice = createSlice({
 		totalSnapshotsPages: null as number,
 	},
 	reducers: {
+		resetMultiMachineRestoreState: (state) => {
+			state.backupSites = [];
+			state.selectedSite = null as BackupSite;
+			state.selectedSnapshot = null as BackupSnapshot;
+			state.isErrored = false;
+			state.activeError = null as SerializedError;
+			return state;
+		},
 		setSelectedSite: (state, action) => {
 			state.selectedSite = action.payload;
 			return state;
@@ -120,6 +128,7 @@ export const multiMachineRestoreSlice = createSlice({
 			.addCase(setMultiMachineProviderAndUpdateSnapshots.fulfilled, (state, action) => {
 				state.isLoading = false;
 				snapshotsEntityAdapter.setAll(state.backupSnapshots, action.payload.snapshots.snapshots);
+				state.selectedSnapshot = null;
 				state.selectedProvider = action.payload.provider;
 				state.currentSnapshotsPage = action.payload.snapshots.pagination.currentPage;
 				state.totalSnapshotsPages = action.payload.snapshots.pagination.lastPage;
@@ -171,14 +180,6 @@ export const selectMultiMachineActiveSiteSnapshots = createSelector(
 			...(hasMore && !isLoading && !isLoadingMoreSnapshots
 				? [{
 					hash: MULTI_MACHINE_SNAPSHOTS_HAS_MORE,
-					id: -1,
-					repoID: -1,
-				} as BackupSnapshot]
-				: []
-			),
-			...(hasMore && isLoadingMoreSnapshots
-				? [{
-					hash: LOADING_MULTI_MACHINE_SNAPSHOTS,
 					id: -1,
 					repoID: -1,
 				} as BackupSnapshot]

--- a/src/renderer/store/multiMachineRestoreSlice.ts
+++ b/src/renderer/store/multiMachineRestoreSlice.ts
@@ -1,7 +1,7 @@
 import {
 	createSlice,
 } from '@reduxjs/toolkit';
-import type { BackupSite } from '../../types';
+import type { BackupSite, BackupSnapshot, HubOAuthProviders } from '../../types';
 
 /**
  * State for the active site.
@@ -10,10 +10,30 @@ export const multiMachineRestoreSlice = createSlice({
 	name: 'multiMachineRestore',
 	initialState: {
 		backupSites: [] as BackupSite[],
+		backupSnapshots: [] as BackupSnapshot[],
+		selectedSite: null as string,
+		selectedSnapshot: null as BackupSnapshot,
+		selectedProvider: null as HubOAuthProviders,
 	},
 	reducers: {
 		setAllBackupSites: (state, action) => {
 			state.backupSites = action.payload;
+			return state;
+		},
+		setBackupSnapshots: (state, action) => {
+			state.backupSnapshots = action.payload;
+			return state;
+		},
+		setSelectedSite: (state, action) => {
+			state.selectedSite = action.payload;
+			return state;
+		},
+		setSelectedSnapshot: (state, action) => {
+			state.selectedSnapshot = action.payload;
+			return state;
+		},
+		setSelectedProvider: (state, action) => {
+			state.selectedProvider = action.payload;
 			return state;
 		},
 	},

--- a/src/renderer/store/multiMachineRestoreSlice.ts
+++ b/src/renderer/store/multiMachineRestoreSlice.ts
@@ -1,5 +1,5 @@
 import {
-	createSlice,
+	createSlice, SerializedError,
 } from '@reduxjs/toolkit';
 import type { BackupSite, BackupSnapshot, HubOAuthProviders, HubProviderRecord } from '../../types';
 import { getSitesList, getSnapshotList, setMultiMachineProviderAndUpdateSnapshots } from './multiMachineThunks';
@@ -18,6 +18,8 @@ export const multiMachineRestoreSlice = createSlice({
 		selectedSnapshot: null as BackupSnapshot,
 		selectedProvider: null as HubProviderRecord,
 		isLoading: false,
+		isErrored: false,
+		activeError: null as SerializedError,
 	},
 	reducers: {
 		setSelectedSite: (state, action) => {
@@ -39,8 +41,10 @@ export const multiMachineRestoreSlice = createSlice({
 				state.backupProviders = action.payload.availableProviders;
 				state.backupSites = action.payload.allSites;
 			})
-			.addCase(getSitesList.rejected, (state) => {
+			.addCase(getSitesList.rejected, (state, action) => {
 				state.isLoading = false;
+				state.isErrored = true;
+				state.activeError = action.payload;
 			})
 			.addCase(getSnapshotList.pending, (state) => {
 				state.isLoading = true;
@@ -51,8 +55,10 @@ export const multiMachineRestoreSlice = createSlice({
 				state.individualSiteRepoProviders = action.payload.individualSiteProviders;
 				state.selectedProvider = action.payload.individualSiteProviders[0];
 			})
-			.addCase(getSnapshotList.rejected, (state) => {
+			.addCase(getSnapshotList.rejected, (state, action) => {
 				state.isLoading = false;
+				state.isErrored = true;
+				state.activeError = action.payload;
 			})
 			.addCase(setMultiMachineProviderAndUpdateSnapshots.pending, (state) => {
 				state.isLoading = true;
@@ -62,8 +68,10 @@ export const multiMachineRestoreSlice = createSlice({
 				state.backupSnapshots = action.payload.snapshots.snapshots;
 				state.selectedProvider = action.payload.provider;
 			})
-			.addCase(setMultiMachineProviderAndUpdateSnapshots.rejected, (state) => {
+			.addCase(setMultiMachineProviderAndUpdateSnapshots.rejected, (state, action) => {
 				state.isLoading = false;
+				state.isErrored = true;
+				state.activeError = action.payload;
 			});
 	},
 });

--- a/src/renderer/store/multiMachineRestoreSlice.ts
+++ b/src/renderer/store/multiMachineRestoreSlice.ts
@@ -2,7 +2,7 @@ import {
 	createSlice,
 } from '@reduxjs/toolkit';
 import type { BackupSite, BackupSnapshot, HubOAuthProviders, HubProviderRecord } from '../../types';
-import { getSitesList, getSnapshotList } from './multiMachineThunks';
+import { getSitesList, getSnapshotList, setMultiMachineProviderAndUpdateSnapshots } from './multiMachineThunks';
 
 /**
  * State for the active site.
@@ -16,7 +16,7 @@ export const multiMachineRestoreSlice = createSlice({
 		individualSiteRepoProviders: [] as HubProviderRecord[],
 		selectedSite: null as BackupSite,
 		selectedSnapshot: null as BackupSnapshot,
-		selectedProvider: null as HubOAuthProviders,
+		selectedProvider: null as HubProviderRecord,
 		isLoading: false,
 	},
 	reducers: {
@@ -52,6 +52,17 @@ export const multiMachineRestoreSlice = createSlice({
 				state.selectedProvider = action.payload.individualSiteProviders[0];
 			})
 			.addCase(getSnapshotList.rejected, (state) => {
+				state.isLoading = false;
+			})
+			.addCase(setMultiMachineProviderAndUpdateSnapshots.pending, (state) => {
+				state.isLoading = true;
+			})
+			.addCase(setMultiMachineProviderAndUpdateSnapshots.fulfilled, (state, action) => {
+				state.isLoading = false;
+				state.backupSnapshots = action.payload.snapshots.snapshots;
+				state.selectedProvider = action.payload.provider;
+			})
+			.addCase(setMultiMachineProviderAndUpdateSnapshots.rejected, (state) => {
 				state.isLoading = false;
 			});
 	},

--- a/src/renderer/store/multiMachineRestoreSlice.ts
+++ b/src/renderer/store/multiMachineRestoreSlice.ts
@@ -1,0 +1,20 @@
+import {
+	createSlice,
+} from '@reduxjs/toolkit';
+import type { BackupSite } from '../../types';
+
+/**
+ * State for the active site.
+ */
+export const multiMachineRestoreSlice = createSlice({
+	name: 'multiMachineRestore',
+	initialState: {
+		backupSites: [] as BackupSite[],
+	},
+	reducers: {
+		setAllBackupSites: (state, action) => {
+			state.backupSites = action.payload;
+			return state;
+		},
+	},
+});

--- a/src/renderer/store/multiMachineRestoreSlice.ts
+++ b/src/renderer/store/multiMachineRestoreSlice.ts
@@ -4,6 +4,7 @@ import {
 import type { BackupSite, BackupSnapshot, HubProviderRecord } from '../../types';
 import {
 	getSitesList,
+	getProvidersList,
 	getSnapshotList,
 	setMultiMachineProviderAndUpdateSnapshots,
 	requestSubsequentSnapshots,
@@ -65,10 +66,22 @@ export const multiMachineRestoreSlice = createSlice({
 			})
 			.addCase(getSitesList.fulfilled, (state, action) => {
 				state.isLoading = false;
-				state.backupProviders = action.payload.availableProviders;
 				state.backupSites = action.payload.allSites;
 			})
 			.addCase(getSitesList.rejected, (state, action) => {
+				state.isLoading = false;
+				state.isErrored = true;
+				state.activeError = action.payload;
+			})
+			// getProviderList cases
+			.addCase(getProvidersList.pending, (state) => {
+				state.isLoading = true;
+			})
+			.addCase(getProvidersList.fulfilled, (state, action) => {
+				state.isLoading = false;
+				state.backupProviders = action.payload.availableProviders;
+			})
+			.addCase(getProvidersList.rejected, (state, action) => {
 				state.isLoading = false;
 				state.isErrored = true;
 				state.activeError = action.payload;
@@ -97,7 +110,7 @@ export const multiMachineRestoreSlice = createSlice({
 			})
 			.addCase(setMultiMachineProviderAndUpdateSnapshots.fulfilled, (state, action) => {
 				state.isLoading = false;
-				state.backupSnapshots = action.payload.snapshots.snapshots;
+				snapshotsEntityAdapter.setAll(state.backupSnapshots, action.payload.snapshots.snapshots);
 				state.selectedProvider = action.payload.provider;
 				state.currentSnapshotsPage = action.payload.snapshots.pagination.currentPage;
 				state.totalSnapshotsPages = action.payload.snapshots.pagination.lastPage;

--- a/src/renderer/store/multiMachineThunks.ts
+++ b/src/renderer/store/multiMachineThunks.ts
@@ -13,7 +13,12 @@ const getProvidersList = createAsyncThunk('multiMachineBackupsGetProviders', asy
 			IPCASYNC_EVENTS.MULTI_MACHINE_GET_AVAILABLE_PROVIDERS,
 		);
 
-		if (!availableProviders.length) {
+		// presence of a message on the response object means we got a connection error
+		if (availableProviders.message) {
+			return rejectWithValue(MULTI_MACHINE_BACKUP_ERRORS.GENERIC_HUB_CONNECTION_ERROR);
+		}
+
+		if (!availableProviders[0]) {
 			return rejectWithValue(MULTI_MACHINE_BACKUP_ERRORS.NO_CONNECTED_PROVIDERS_FOR_SITE);
 		}
 
@@ -29,11 +34,11 @@ const getSitesList = createAsyncThunk('multiMachineBackupsGetSites', async (_, {
 			IPCASYNC_EVENTS.GET_ALL_SITES,
 		);
 
+		LocalRenderer.sendIPCEvent('goToRoute', LOCAL_ROUTES.ADD_SITE_BACKUP_SITE);
+
 		if (!allSites.length) {
 			return rejectWithValue(MULTI_MACHINE_BACKUP_ERRORS.NO_SITES_FOUND);
 		}
-
-		LocalRenderer.sendIPCEvent('goToRoute', LOCAL_ROUTES.ADD_SITE_BACKUP_SITE);
 
 		return { allSites };
 	} catch (error) {

--- a/src/renderer/store/multiMachineThunks.ts
+++ b/src/renderer/store/multiMachineThunks.ts
@@ -18,12 +18,10 @@ const getSitesList = createAsyncThunk('multiMachineBackupsGetSites', async (_, {
 		);
 
 		if (!availableProviders.length) {
-			// Could not find any providers, please check you have providers enabled
 			return rejectWithValue(MULTI_MACHINE_BACKUP_ERRORS.NO_PROVIDERS_FOUND);
 		}
 
 		if (!allSites.length) {
-			// Could not find any sites on the cloud, please make sure you're logged into the right Hub account
 			return rejectWithValue(MULTI_MACHINE_BACKUP_ERRORS.NO_SITES_FOUND);
 		}
 
@@ -31,7 +29,6 @@ const getSitesList = createAsyncThunk('multiMachineBackupsGetSites', async (_, {
 
 		return { availableProviders, allSites };
 	} catch (error) {
-		// Could not authenticate connection
 		return rejectWithValue(error.toString());
 	}
 });
@@ -65,7 +62,6 @@ const getSnapshotList = createAsyncThunk('multiMachineBackupsGetSnapshots', asyn
 			);
 
 			if (!snapshots.snapshots.length) {
-				// Could not find any backups of this site, please make sure you're connected to a storage provider
 				return rejectWithValue(MULTI_MACHINE_BACKUP_ERRORS.NO_SNAPSHOTS_FOUND);
 			}
 
@@ -77,7 +73,6 @@ const getSnapshotList = createAsyncThunk('multiMachineBackupsGetSnapshots', asyn
 
 		return rejectWithValue(MULTI_MACHINE_BACKUP_ERRORS.NO_CONNECTED_PROVIDERS_FOR_SITE);
 	} catch (error) {
-		// throw warning banner
 		return rejectWithValue(error.toString());
 	}
 });
@@ -95,7 +90,6 @@ const setMultiMachineProviderAndUpdateSnapshots = createAsyncThunk('multiMachine
 			);
 
 			if (!snapshots.snapshots.length) {
-				// Could not find any backups of this site, please make sure you're connected to a storage provider
 				return rejectWithValue(MULTI_MACHINE_BACKUP_ERRORS.NO_SNAPSHOTS_FOUND);
 			}
 
@@ -104,7 +98,6 @@ const setMultiMachineProviderAndUpdateSnapshots = createAsyncThunk('multiMachine
 				provider,
 			};
 		} catch (error) {
-			// throw warning banner
 			return rejectWithValue(error.toString());
 		}
 	});

--- a/src/renderer/store/multiMachineThunks.ts
+++ b/src/renderer/store/multiMachineThunks.ts
@@ -1,5 +1,5 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import { IPCASYNC_EVENTS, MULTI_MACHINE_BACKUP_ERRORS } from '../../constants';
+import { IPCASYNC_EVENTS, LOCAL_ROUTES, MULTI_MACHINE_BACKUP_ERRORS } from '../../constants';
 import { ipcAsync } from '@getflywheel/local/renderer';
 import type { AppState } from './store';
 
@@ -25,7 +25,7 @@ const getSitesList = createAsyncThunk('multiMachineBackupsGetSites', async (_, {
 			return rejectWithValue(MULTI_MACHINE_BACKUP_ERRORS.NO_SITES_FOUND);
 		}
 
-		LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/select-site-backup');
+		LocalRenderer.sendIPCEvent('goToRoute', LOCAL_ROUTES.ADD_SITE_BACKUP_SITE);
 
 		return { availableProviders, allSites };
 	} catch (error) {

--- a/src/renderer/store/multiMachineThunks.ts
+++ b/src/renderer/store/multiMachineThunks.ts
@@ -102,8 +102,35 @@ const setMultiMachineProviderAndUpdateSnapshots = createAsyncThunk('multiMachine
 		}
 	});
 
+const requestSubsequentSnapshots = createAsyncThunk('multiMachineBackupsRequestSubsequentSnapshots',
+	async (_, { getState, rejectWithValue }) => {
+		const state = getState() as AppState;
+		const { selectedSite, currentSnapshotsPage, selectedProvider } = state.multiMachineRestore;
+		const nextPage = currentSnapshotsPage + 1;
+		try {
+			const snapshots = await ipcAsync(
+				IPCASYNC_EVENTS.GET_ALL_SNAPSHOTS,
+				selectedSite.uuid,
+				selectedProvider.id,
+				nextPage,
+			);
+
+			if (!snapshots.snapshots.length) {
+				return rejectWithValue(MULTI_MACHINE_BACKUP_ERRORS.NO_SNAPSHOTS_FOUND);
+			}
+
+			return {
+				snapshots,
+			};
+		} catch (error) {
+			return rejectWithValue(error.toString());
+		}
+	},
+);
+
 export {
 	getSitesList,
 	getSnapshotList,
 	setMultiMachineProviderAndUpdateSnapshots,
+	requestSubsequentSnapshots,
 };

--- a/src/renderer/store/multiMachineThunks.ts
+++ b/src/renderer/store/multiMachineThunks.ts
@@ -1,0 +1,71 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { IPCASYNC_EVENTS } from '../../constants';
+import { ipcAsync } from '@getflywheel/local/renderer';
+import type { AppState } from './store';
+
+import * as LocalRenderer from '@getflywheel/local/renderer';
+import { BackupRepo } from '../../types';
+
+
+const getSitesList = createAsyncThunk('multiMachineBackupsGetSites', async () => {
+	try {
+		const availableProviders = await ipcAsync(
+			IPCASYNC_EVENTS.MULTI_MACHINE_GET_AVAILABLE_PROVIDERS,
+		);
+
+		const allSites = await ipcAsync(
+			IPCASYNC_EVENTS.GET_ALL_SITES,
+		);
+
+		LocalRenderer.sendIPCEvent('goToRoute', '/main/add-site/select-site-backup');
+
+		return { availableProviders, allSites };
+	} catch (error) {
+		console.log(error);
+		// throw warning banner
+		return error;
+	}
+});
+
+const getSnapshotList = createAsyncThunk('multiMachineBackupsGetSnapshots', async (_, { dispatch, getState }) => {
+	try {
+		const state = getState() as AppState;
+		const { backupProviders, selectedSite } = state.multiMachineRestore;
+
+		// query repo by site id
+		const siteRepos = await ipcAsync(
+			IPCASYNC_EVENTS.GET_REPOS_BY_SITE_ID,
+			selectedSite.id,
+		);
+
+		// determine if the site the user has selected has snapshots on multiple providers
+		const individualSiteProviders = backupProviders.filter((provider) => {
+			const matchedRepoToProvider = siteRepos.find((repo: BackupRepo) => repo.providerID === provider.id);
+			if (matchedRepoToProvider) {
+				return matchedRepoToProvider;
+			}
+		});
+
+		if (individualSiteProviders.length) {
+			const snapshots = await ipcAsync(
+				IPCASYNC_EVENTS.GET_ALL_SNAPSHOTS,
+				selectedSite.uuid,
+				individualSiteProviders[0].id,
+			);
+
+			return {
+				snapshots,
+				individualSiteProviders,
+			};
+		}
+	} catch (error) {
+		console.log(error);
+		// throw warning banner
+		return error;
+	}
+});
+
+export {
+	getSitesList,
+	getSnapshotList,
+};

--- a/src/renderer/store/multiMachineThunks.ts
+++ b/src/renderer/store/multiMachineThunks.ts
@@ -33,8 +33,10 @@ const getSitesList = createAsyncThunk('multiMachineBackupsGetSites', async (_, {
 			IPCASYNC_EVENTS.GET_ALL_SITES,
 		);
 
-		// todo - tyler - refactor to remove this logic from the thunk actions
-		LocalRenderer.sendIPCEvent('goToRoute', LOCAL_ROUTES.ADD_SITE_BACKUP_SITE);
+		// presence of a message on the response object means we got a connection error
+		if (allSites.message) {
+			return rejectWithValue(MULTI_MACHINE_BACKUP_ERRORS.GENERIC_HUB_CONNECTION_ERROR);
+		}
 
 		if (!allSites.length) {
 			return rejectWithValue(MULTI_MACHINE_BACKUP_ERRORS.NO_SITES_FOUND);

--- a/src/renderer/store/multiMachineThunks.ts
+++ b/src/renderer/store/multiMachineThunks.ts
@@ -4,7 +4,7 @@ import { ipcAsync } from '@getflywheel/local/renderer';
 import type { AppState } from './store';
 
 import * as LocalRenderer from '@getflywheel/local/renderer';
-import { BackupRepo } from '../../types';
+import { BackupRepo, HubProviderRecord } from '../../types';
 
 
 const getSitesList = createAsyncThunk('multiMachineBackupsGetSites', async () => {
@@ -27,7 +27,7 @@ const getSitesList = createAsyncThunk('multiMachineBackupsGetSites', async () =>
 	}
 });
 
-const getSnapshotList = createAsyncThunk('multiMachineBackupsGetSnapshots', async (_, { dispatch, getState }) => {
+const getSnapshotList = createAsyncThunk('multiMachineBackupsGetSnapshots', async (_, { getState }) => {
 	try {
 		const state = getState() as AppState;
 		const { backupProviders, selectedSite } = state.multiMachineRestore;
@@ -65,7 +65,31 @@ const getSnapshotList = createAsyncThunk('multiMachineBackupsGetSnapshots', asyn
 	}
 });
 
+const setMultiMachineProviderAndUpdateSnapshots = createAsyncThunk('multiMachineBackupsSetProviderAndUpdateSnapshots',
+	async (provider: HubProviderRecord, { getState }) => {
+		const state = getState() as AppState;
+		const { selectedSite } = state.multiMachineRestore;
+
+		try {
+			const snapshots = await ipcAsync(
+				IPCASYNC_EVENTS.GET_ALL_SNAPSHOTS,
+				selectedSite.uuid,
+				provider.id,
+			);
+
+			return {
+				snapshots,
+				provider,
+			};
+		} catch (error) {
+			console.log(error);
+			// throw warning banner
+			return error;
+		}
+	});
+
 export {
 	getSitesList,
 	getSnapshotList,
+	setMultiMachineProviderAndUpdateSnapshots,
 };

--- a/src/renderer/store/selectors.ts
+++ b/src/renderer/store/selectors.ts
@@ -1,5 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit';
-import { AppState } from './store';
+import state from '../../main/services/state';
+import { AppState, store } from './store';
 
 /**
  * The selected/active provider derived from the current active site and known providers.
@@ -20,9 +21,15 @@ const selectActiveProvider = createSelector(
 	},
 );
 
+const selectAllBackupSites = createSelector(
+	() => store.getState(),
+	({ multiMachineRestore }) => multiMachineRestore.backupSites,
+);
+
 /**
  * Organized export of available selectors.
  */
 export const selectors = {
 	selectActiveProvider,
+	selectAllBackupSites,
 };

--- a/src/renderer/store/selectors.ts
+++ b/src/renderer/store/selectors.ts
@@ -36,6 +36,16 @@ const selectBackupSite = createSelector(
 	({ multiMachineRestore }) => multiMachineRestore.selectedSite,
 );
 
+const selectAllSnapshots = createSelector(
+	() => store.getState(),
+	({ multiMachineRestore }) => multiMachineRestore.backupSnapshots,
+);
+
+const selectActiveSnapshot = createSelector(
+	() => store.getState(),
+	({ multiMachineRestore }) => multiMachineRestore.selectedSnapshot,
+);
+
 /**
  * Organized export of available selectors.
  */
@@ -44,4 +54,6 @@ export const selectors = {
 	selectAllBackupSites,
 	selectEnabledProvider,
 	selectBackupSite,
+	selectAllSnapshots,
+	selectActiveSnapshot,
 };

--- a/src/renderer/store/selectors.ts
+++ b/src/renderer/store/selectors.ts
@@ -26,10 +26,22 @@ const selectAllBackupSites = createSelector(
 	({ multiMachineRestore }) => multiMachineRestore.backupSites,
 );
 
+const selectEnabledProvider = createSelector(
+	() => store.getState(),
+	({ multiMachineRestore }) => multiMachineRestore.selectedProvider,
+);
+
+const selectBackupSite = createSelector(
+	() => store.getState(),
+	({ multiMachineRestore }) => multiMachineRestore.selectedSite,
+);
+
 /**
  * Organized export of available selectors.
  */
 export const selectors = {
 	selectActiveProvider,
 	selectAllBackupSites,
+	selectEnabledProvider,
+	selectBackupSite,
 };

--- a/src/renderer/store/selectors.ts
+++ b/src/renderer/store/selectors.ts
@@ -21,29 +21,9 @@ const selectActiveProvider = createSelector(
 	},
 );
 
-const selectAllBackupSites = createSelector(
+const selectMultiMachineSliceState = createSelector(
 	() => store.getState(),
-	({ multiMachineRestore }) => multiMachineRestore.backupSites,
-);
-
-const selectEnabledProvider = createSelector(
-	() => store.getState(),
-	({ multiMachineRestore }) => multiMachineRestore.selectedProvider,
-);
-
-const selectBackupSite = createSelector(
-	() => store.getState(),
-	({ multiMachineRestore }) => multiMachineRestore.selectedSite,
-);
-
-const selectAllSnapshots = createSelector(
-	() => store.getState(),
-	({ multiMachineRestore }) => multiMachineRestore.backupSnapshots,
-);
-
-const selectActiveSnapshot = createSelector(
-	() => store.getState(),
-	({ multiMachineRestore }) => multiMachineRestore.selectedSnapshot,
+	({ multiMachineRestore }) => multiMachineRestore,
 );
 
 /**
@@ -51,9 +31,5 @@ const selectActiveSnapshot = createSelector(
  */
 export const selectors = {
 	selectActiveProvider,
-	selectAllBackupSites,
-	selectEnabledProvider,
-	selectBackupSite,
-	selectAllSnapshots,
-	selectActiveSnapshot,
+	selectMultiMachineSliceState,
 };

--- a/src/renderer/store/selectors.ts
+++ b/src/renderer/store/selectors.ts
@@ -1,5 +1,4 @@
 import { createSelector } from '@reduxjs/toolkit';
-import state from '../../main/services/state';
 import { AppState, store } from './store';
 
 /**

--- a/src/renderer/store/store.ts
+++ b/src/renderer/store/store.ts
@@ -1,6 +1,7 @@
 import { useSelector, TypedUseSelectorHook } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import * as thunks from './thunks';
+import * as multiMachineThunks from './multiMachineThunks';
 import { activeSiteSlice } from './activeSiteSlice';
 import { directorSlice } from './directorSlice';
 import { providersSlice } from './providersSlice';
@@ -18,6 +19,7 @@ export const actions = {
 	...multiMachineRestoreSlice.actions,
 	// include all thunks here to make it easier to reference both actions and thunks from same place
 	...thunks,
+	...multiMachineThunks,
 };
 
 /**

--- a/src/renderer/store/store.ts
+++ b/src/renderer/store/store.ts
@@ -5,6 +5,7 @@ import { activeSiteSlice } from './activeSiteSlice';
 import { directorSlice } from './directorSlice';
 import { providersSlice } from './providersSlice';
 import { snapshotsSlice } from './snapshotsSlice';
+import { multiMachineRestoreSlice } from './multiMachineRestoreSlice';
 
 /**
  * Convenience collection of Redux actions.
@@ -14,6 +15,7 @@ export const actions = {
 	...directorSlice.actions,
 	...providersSlice.actions,
 	...snapshotsSlice.actions,
+	...multiMachineRestoreSlice.actions,
 	// include all thunks here to make it easier to reference both actions and thunks from same place
 	...thunks,
 };
@@ -27,6 +29,7 @@ export const store = configureStore({
 		director: directorSlice.reducer,
 		providers: providersSlice.reducer,
 		snapshots: snapshotsSlice.reducer,
+		multiMachineRestore: multiMachineRestoreSlice.reducer,
 	},
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
-import type { Site as SiteBase } from '@getflywheel/local';
+import { LocalState } from '@apollo/client/core/LocalState';
+import type { Site as SiteBase, NewSiteInfo } from '@getflywheel/local';
 
 export type GenericObject = { [key: string]: any };
 
@@ -8,6 +9,15 @@ export type GenericObject = { [key: string]: any };
  */
 export interface Site extends SiteBase {
 	localBackupRepoID?: string;
+	cloudBackupMeta?: {
+		createdFromCloudBackup?: boolean,
+		snapshotID?: string,
+		provider?: HubProviderRecord,
+		repoID?: string,
+	};
+}
+
+export interface NewSiteInfoWithCloudMeta extends NewSiteInfo {
 	cloudBackupMeta?: {
 		createdFromCloudBackup?: boolean,
 		snapshotID?: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export interface Site extends SiteBase {
 	cloudBackupMeta?: {
 		createdFromCloudBackup?: boolean,
 		snapshotID?: string,
-		provider?: string,
+		provider?: HubProviderRecord,
 		repoID?: string,
 	};
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,12 @@ export type GenericObject = { [key: string]: any };
  */
 export interface Site extends SiteBase {
 	localBackupRepoID?: string;
+	cloudBackupMeta?: {
+		createdFromCloudBackup?: boolean,
+		snapshotID?: string,
+		provider?: string,
+		repoID?: string,
+	};
 }
 
 type SiteMetaDataBase = Pick<SiteBase,

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export interface BackupSite {
 	id: number;
 	uuid: string;
 	password: string;
+	name?: string;
 }
 
 export interface BackupRepo {

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,7 @@ export interface BackupSnapshot {
 	updatedAt?: number;
 	config?: string;
 	configObject?: GenericObject;
+	createdAt?: number;
 	siteId: string;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -598,10 +598,10 @@
   resolved "https://registry.yarnpkg.com/@getflywheel/eslint-config-local/-/eslint-config-local-1.0.4.tgz#2fab6bb77b63ec123e831534f50e1d3c7c135571"
   integrity sha512-GvnhhT3XaNipDdVvHifWbKjoFpLAbezkKsYBGfDF4uG/9gWo5UX9YLANPlzSLRyvgBrX0+27S5Cu8YE/yM7kPg==
 
-"@getflywheel/local-components@16.1.1":
-  version "16.1.1"
-  resolved "https://registry.yarnpkg.com/@getflywheel/local-components/-/local-components-16.1.1.tgz#ef1540cf1467a2cddd06944a61a4a66389e2bcde"
-  integrity sha512-QO5U9QB+n8KvLA1aWmkFiklvfNZQDOCiXnQj9N2IMLA20P8JnfccAN6nDkaZeTlqwv1Id6FaLvyQSFP3Y6Y/QA==
+"@getflywheel/local-components@16.2.3":
+  version "16.2.3"
+  resolved "https://registry.yarnpkg.com/@getflywheel/local-components/-/local-components-16.2.3.tgz#d9aa89f493418078b8e684c82844649508237171"
+  integrity sha512-LjJYnEATpFkHmSjFrS852qKXNWWE0cnHeU+lnsZdIkMpbBrmIMw6C59/jZ9hFXz5jG4vw72hGZqNm5FGINbc2Q==
   dependencies:
     "@getflywheel/memoize-one-ts" "^0.0.2"
     "@popperjs/core" "^2.9.2"


### PR DESCRIPTION
## Summary

This PR adds a new feature to the Cloud Backups addon that allows users to restore a backup via the "Add Site" user flow. This lets a user choose a site to restore from the complete list of sites available to them on their Cloud Provider(s), rather than needing to have the site active on their current Local install to run a clone or restore.

Important note: there are two extra improvements to this body of work that will be tackled in follow up tickets - updating the Local Database with the correct URL after the site is restored, and adding a site name as part of the site creation process.

## Technical
The current "addSite" workflow in Local involves the user walking through a multi-step process, selecting data about the new Local site they're creating. Behind the scenes, this means that a `NewSiteInfo` object is created and added to, and eventually submitted via IPC event to the backend, being passed to the service method `addSite` in `AddSiteService.ts`

This PR adds a UI for the user to build out and submit a compatible `NewSiteInfo` object that provisions an initial site placeholder, and then kicks off a restore to that new site of the user's selected Cloud Backup snapshot.

This requires:
- new routes and components to Local for the Add Site user flow
- adding a new key/object pair to the "NewSiteInfo" object to track Cloud Backup specific data
- lots of data juggling and handoff via IPC events between render / main and via Local Hooks between core / addon code.

This is best reviewed in parallel to the Local Core PR located here: https://github.com/getflywheel/flywheel-local/pull/1156

I recommend reviewing this PR by looking at it in 4 main chunks:

1 - the new redux slice and new redux thunks - `multiMachineRestoreSlice.ts` and `multiMachineThunks.ts`
2 - the new components for the UI, located in `renderer/components/multimachinebackups`
3 - the new hooks added to `renderer.tsx` and `main.ts`
4 - the new IPC events added to `main.ts`

These 4 areas is where the bulk of the functionality can be found. Most other changes are added constants, and small tweaks to existing services or components to make them compatible with the new functionality.

It's also important to know that some of the hooks pass in important data and methods from core Local, including:

- defaultLocalSettings - object that contains default Local constants like the `.local` tld and more
- formatSiteNicename - helper function to determine standardized site name conventions
- osPath - helper function to determine standardized pathing
- siteSettings - object used to compose the site during the "Add Site" user flow

## Screenshots

Here's a video since there's so much to include for screenshots:

https://user-images.githubusercontent.com/7596682/128398785-7ff2db1b-8d66-4b34-b64f-b2c259d27acd.mov

What things look like if you're logged out:

<img width="1361" alt="Screen Shot 2021-08-05 at 1 06 38 PM" src="https://user-images.githubusercontent.com/7596682/128399525-5af97f17-0b6c-40df-a35a-26bfe3e2bb69.png">

Error state if you have no sites created for your account yet:
<img width="1361" alt="Screen Shot 2021-08-05 at 1 15 45 PM" src="https://user-images.githubusercontent.com/7596682/128400602-7ac1d20f-489f-4807-8379-de774aa9b4b7.png">

## Ticket Reference
- https://wpengine.atlassian.net/browse/LOC-197