### PR TITLE
feat: Allow setting the sitename when creating site from backup.

### DIFF
--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { ApolloProvider } from '@apollo/client';
 import { RestoreStates, BackupStates } from './types';
-import { store } from './renderer/store/store';
+import { store, actions } from './renderer/store/store';
 import SiteInfoToolsSection from './renderer/components/siteinfotools/SiteInfoToolsSection';
 import { setupListeners } from './renderer/helpers/setupListeners';
 import { client } from './renderer/localClient/localGraphQLClient';
@@ -101,6 +101,9 @@ export default function (context): void {
 					goToSite: true,
 					installWP: false,
 				});
+
+				// Reset the user selected options from the add site flow.
+				store.dispatch(actions.resetMultiMachineRestoreState());
 			};
 
 			const onGoBack = () => {
@@ -111,7 +114,7 @@ export default function (context): void {
 				...newSiteEnvironmentProps,
 				onContinue: continueCreateSite,
 				onGoBack,
-				buttonText: 'Restore Site',
+				buttonText: 'Add Site',
 			};
 		}
 
@@ -132,7 +135,7 @@ export default function (context): void {
 					done={localHistory.location.pathname !== LOCAL_ROUTES.ADD_SITE_BACKUP_SITE}
 					active={localHistory.location.pathname === LOCAL_ROUTES.ADD_SITE_BACKUP_SITE}
 				>
-					Select Site
+					Select Site and Name
 				</Step>
 				<Step
 					key={'choose-snapshot'}
@@ -148,7 +151,7 @@ export default function (context): void {
 					done={false}
 					active={localHistory.location.pathname === LOCAL_ROUTES.ADD_SITE_ENVIRONMENT}
 				>
-					Setup Environment
+					Set Up Environment
 				</Step>
 			</Stepper>
 		);

--- a/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
+++ b/src/renderer/components/multimachinebackups/ChooseCreateSite.tsx
@@ -66,7 +66,7 @@ export const ChooseCreateSite = () => {
 	return (
 		<>
 			<div className="AddSiteContent">
-				<Title size="l" container={{ margin: 'l 0' }}>Select the type of site you want to add</Title>
+				<Title size="l" container={{ margin: 'l 0' }}>Create a site</Title>
 				<div className="Inner">
 					<RadioBlock
 						className={styles.radioBlock}
@@ -79,7 +79,7 @@ export const ChooseCreateSite = () => {
 							},
 							usebackup: {
 								key: 'use-cloud-backup',
-								label: 'Restore a site from Cloud Backups Add-on',
+								label: 'Create a site from Cloud Backups Add-on',
 								className: 'TID_NewSiteEnvironment_RadioBlockItem_Custom',
 								disabled: providerIsErrored,
 								container: {
@@ -123,7 +123,7 @@ export const ChooseCreateSite = () => {
 						onDismiss={onPromoBannerDismiss}
 						icon="none"
 					>
-						<p>&#127881;</p><p>You can now restore a site from a Cloud Backup! Select to restore a site to get started.</p>
+						<p>&#127881;</p><p>You can now create a site from a Cloud Backup! Select this option to get started.</p>
 					</Banner>}
 				</div>
 				<PrimaryButton

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.scss
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.scss
@@ -1,3 +1,5 @@
+@import '~@getflywheel/local-components/src/styles/_partials/index';
+
 .innerContainer {
 	width: 644px;
 	align-self: center;
@@ -19,4 +21,17 @@
 	position: absolute;
 	bottom: 30px;
 	right: 30px;
+}
+
+.errorText {
+	color: $red;
+	font-weight: 500;
+}
+
+.errorTextContainer {
+	margin-top: 10px;
+}
+
+.errorState {
+	box-shadow: inset 0 0 0 2px $red !important;
 }

--- a/src/renderer/store/multiMachineRestoreSlice.ts
+++ b/src/renderer/store/multiMachineRestoreSlice.ts
@@ -29,6 +29,7 @@ export const multiMachineRestoreSlice = createSlice({
 		// sites
 		backupSites: [] as BackupSite[],
 		selectedSite: null as BackupSite,
+		newSiteName: '',
 
 		// snapshots
 		backupSnapshots: snapshotsEntityAdapter.getInitialState(),
@@ -52,6 +53,7 @@ export const multiMachineRestoreSlice = createSlice({
 		resetMultiMachineRestoreState: (state) => {
 			state.backupSites = [];
 			state.selectedSite = null as BackupSite;
+			state.newSiteName = '';
 			state.selectedSnapshot = null as BackupSnapshot;
 			state.isErrored = false;
 			state.activeError = null as SerializedError;
@@ -59,6 +61,12 @@ export const multiMachineRestoreSlice = createSlice({
 		},
 		setSelectedSite: (state, action) => {
 			state.selectedSite = action.payload;
+			// Set default sitename to sitename-backup.
+			state.newSiteName = `${action.payload.name}-backup`;
+			return state;
+		},
+		setNewSiteName: (state, action) => {
+			state.newSiteName = action.payload;
 			return state;
 		},
 		setSelectedSnapshot: (state, action) => {


### PR DESCRIPTION
This PR includes the ability to name a site when you create it from a backup, and a few copy changes! 

https://user-images.githubusercontent.com/142006/130287266-4d836320-4abd-4802-b811-54140ab26c47.mov

I also resolved a small bug where the site you selected during the add site flow would persist the next time you went to clone from a backup.