### PR TITLE
fix: Increase maxBuffer for exec calls.

### DIFF
--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -97,6 +97,8 @@ async function execPromise (cmd: string, site: Site, env: { [key: string]: strin
 		exec(
 			cmd,
 			{
+				// 4 times the default.
+				maxBuffer: 1024 * 1024 * 4,
 				env: {
 					...process.env,
 					...env,


### PR DESCRIPTION
When backing up large sites, especially on Windows, it's possible to get the following error: 

```
ERR_CHILD_PROCESS_STDIO_MAXBUFER
```

Quick research shows this is caused by using up the default buffer size when making exec calls. So lets bump this number up while we look into a more sustainable solution, like streams! 