### PR TITLE
feat(LOC-2801): offline behavior for cloud backups

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@babel/preset-react": "^7.12.13",
     "@getflywheel/eslint-config-local": "^1.0.4",
-    "@getflywheel/local": ">=5.9.0",
+    "@getflywheel/local": ">=6.1.2",
     "@types/classnames": "^2.2.11",
     "@types/dateformat": "^3.0.1",
     "@types/jest": "^26.0.15",
@@ -75,7 +75,7 @@
   "dependencies": {
     "@apollo/client": "^3.3.15",
     "@electron/remote": "^1.1.0",
-    "@getflywheel/local-components": "16.2.3",
+    "@getflywheel/local-components": "16.3.1",
     "@reduxjs/toolkit": "^1.5.0",
     "classnames": "^2.2.6",
     "cross-fetch": "^3.1.4",
@@ -86,6 +86,8 @@
     "graphql": "^15.5.0",
     "graphql-tag": "^2.11.0",
     "lodash": "^4.17.20",
+    "mobx": "^5.14.0",
+    "mobx-react": "^6.1.4",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-redux": "^7.2.2",
@@ -117,6 +119,6 @@
     "xstate"
   ],
   "engines": {
-    "local-by-flywheel": ">=6.1.1"
+    "local-by-flywheel": ">=6.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "@apollo/client": "^3.3.15",
     "@electron/remote": "^1.1.0",
-    "@getflywheel/local-components": "16.3.2",
+    "@getflywheel/local-components": "16.3.3",
     "@reduxjs/toolkit": "^1.5.0",
     "classnames": "^2.2.6",
     "cross-fetch": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "@apollo/client": "^3.3.15",
     "@electron/remote": "^1.1.0",
-    "@getflywheel/local-components": "16.3.1",
+    "@getflywheel/local-components": "16.3.2",
     "@reduxjs/toolkit": "^1.5.0",
     "classnames": "^2.2.6",
     "cross-fetch": "^3.1.4",

--- a/src/renderer/components/siteinfotools/ProviderDropdown.scss
+++ b/src/renderer/components/siteinfotools/ProviderDropdown.scss
@@ -16,7 +16,7 @@
 			fill: $green-dark !important;
 		}
 
-		&:global(.FlyDropdown__Open .FlyDropdown_Caret) {
+		&:global(.FlyDropdown.Popper__Showing .FlyDropdown_Caret) {
 			background: $green-dark;
 		}
 	}
@@ -29,7 +29,7 @@
 		}
 	}
 
-	&:global(.FlyDropdown__Open .FlyDropdown_Caret) {
+	&:global(.FlyDropdown.Popper__Showing .FlyDropdown_Caret) {
 		background: $green;
 	}
 
@@ -40,6 +40,35 @@
 			z-index: 8;
 		}
 	}
+
+	&.ProviderDropdownOffline {
+		color: $gray75;
+	
+		> svg:not(.ProviderDropdown_Content_ProviderSvg) path {
+			fill: $gray75;
+		}
+	
+		&:global(.FlyDropdown.Popper__Showing .FlyDropdown_Caret) {
+			background: $gray75;
+		}
+	
+		&:hover {
+			color: $gray75;
+	
+			> svg:not(.ProviderDropdown_Content_ProviderSvg) path {
+				fill: $gray75 !important;
+			}
+	
+			&:global(.FlyDropdown.Popper__Showing .FlyDropdown_Caret) {
+				background: $gray75;
+			}
+		}
+	}
+}
+
+.DropdownItemOffline {
+	font-weight: 300;
+	padding: 10px 15px !important;
 }
 
 .ProviderDropdown_List {
@@ -83,7 +112,7 @@
 			fill: $green-dark !important;
 		}
 
-		&:global(.FlyDropdown__Open .FlyDropdown_Caret) {
+		&:global(.FlyDropdown.Popper__Showing .FlyDropdown_Caret) {
 			background: $green-dark;
 		}
 	}

--- a/src/renderer/components/siteinfotools/ProviderDropdown.tsx
+++ b/src/renderer/components/siteinfotools/ProviderDropdown.tsx
@@ -122,6 +122,7 @@ export const ProviderDropdown = (props: Props) => {
 				classNameListItem={classnames({ [styles.DropdownItemOffline]: offline })}
 				items={dropdownItems}
 				position="bottom"
+				useClickInsteadOfHover={!offline}
 			>
 				{enabledProviders?.length && activeSiteProvider
 					? (

--- a/src/renderer/components/siteinfotools/ProviderDropdown.tsx
+++ b/src/renderer/components/siteinfotools/ProviderDropdown.tsx
@@ -117,9 +117,9 @@ export const ProviderDropdown = (props: Props) => {
 				{multiMachineSelect ? 'Create new site from' : 'Back up to'}
 			</span>
 			<FlyDropdown
-				className={`${styles.ProviderDropdown} ${offline ? styles.ProviderDropdownOffline : ''}`}
+				className={classnames(styles.ProviderDropdown, { [styles.ProviderDropdownOffline]: offline })}
 				classNameList={styles.ProviderDropdown_List}
-				classNameListItem={offline ? styles.DropdownItemOffline : ''}
+				classNameListItem={classnames({ [styles.DropdownItemOffline]: offline })}
 				items={dropdownItems}
 				position="bottom"
 			>

--- a/src/renderer/components/siteinfotools/ProviderDropdown.tsx
+++ b/src/renderer/components/siteinfotools/ProviderDropdown.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../store/store';
 
 interface Props {
+	offline: boolean,
 	enabledProviders: HubProviderRecord[];
 	activeSiteProvider: HubProviderRecord;
 	multiMachineSelect: boolean;
@@ -73,10 +74,15 @@ const renderDropdownProviderItem = (provider?: HubProviderRecord, isActiveProvid
 );
 
 export const ProviderDropdown = (props: Props) => {
-	const { enabledProviders, activeSiteProvider, multiMachineSelect, siteId } = props;
+	const { offline, enabledProviders, activeSiteProvider, multiMachineSelect, siteId } = props;
 	const dropdownItems: React.ComponentProps<typeof FlyDropdown>['items'] = [];
-
-	if (enabledProviders?.length) {
+	if (offline) {
+		dropdownItems.push({
+			color: 'none',
+			content: <>Check internet connection</>,
+			onClick: null,
+		});
+	} else if (enabledProviders?.length) {
 		enabledProviders.forEach((provider) => {
 			dropdownItems.push({
 				color: 'none',
@@ -111,8 +117,9 @@ export const ProviderDropdown = (props: Props) => {
 				{multiMachineSelect ? 'Create new site from' : 'Back up to'}
 			</span>
 			<FlyDropdown
-				className={styles.ProviderDropdown}
+				className={`${styles.ProviderDropdown} ${offline ? styles.ProviderDropdownOffline : ''}`}
 				classNameList={styles.ProviderDropdown_List}
+				classNameListItem={offline ? styles.DropdownItemOffline : ''}
 				items={dropdownItems}
 				position="bottom"
 			>

--- a/src/renderer/components/siteinfotools/SiteInfoToolsSection.tsx
+++ b/src/renderer/components/siteinfotools/SiteInfoToolsSection.tsx
@@ -14,32 +14,32 @@ interface Props {
 	site: Site;
 }
 
-const SiteInfoToolsSection = ({ site }: Props) => {
-	// update active site anytime the site prop changes
-	useUpdateActiveSiteAndDataSources(site.id);
+const SiteInfoToolsSection = ({ site }: Props) => (
+	useObserver(() => {
+		// update active site anytime the site prop changes
+		useUpdateActiveSiteAndDataSources(site.id);
 
-	const {
-		hasErrorLoadingEnabledProviders,
-	} = useStoreSelector((state) => state.providers);
-	const { id } = useStoreSelector((state) => state.activeSite);
+		const {
+			hasErrorLoadingEnabledProviders,
+		} = useStoreSelector((state) => state.providers);
+		const { id } = useStoreSelector((state) => state.activeSite);
 
-	/**
-	 * @todo sometimes the query to hub fails (like if the auth token has expired)
-	 * we should handle that more gracefully
-	 */
+		/**
+		 * @todo sometimes the query to hub fails (like if the auth token has expired)
+		 * we should handle that more gracefully
+		 */
 
-	if (hasErrorLoadingEnabledProviders) {
-		return (
-			<div className={styles.SiteInfoToolsSection}>
-				<TryAgain
-					message={'There was an issue retrieving your Cloud Backups providers.'}
-					onClick={() => store.dispatch(getEnabledProvidersHub({ siteId: id }))}
-				/>
-			</div>
-		);
-	}
+		if (hasErrorLoadingEnabledProviders) {
+			return (
+				<div className={styles.SiteInfoToolsSection}>
+					<TryAgain
+						message={'There was an issue retrieving your Cloud Backups providers.'}
+						onClick={() => store.dispatch(getEnabledProvidersHub({ siteId: id }))}
+					/>
+				</div>
+			);
+		}
 
-	return useObserver(() => {
 		const { offline } = $offline;
 
 		return (
@@ -53,7 +53,7 @@ const SiteInfoToolsSection = ({ site }: Props) => {
 				/>
 			</div>
 		);
-	});
-};
+	})
+);
 
 export default SiteInfoToolsSection;

--- a/src/renderer/components/siteinfotools/SiteInfoToolsSection.tsx
+++ b/src/renderer/components/siteinfotools/SiteInfoToolsSection.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Site } from '@getflywheel/local';
-import { LoadingIndicator } from '@getflywheel/local-components';
+import { OfflineBanner } from '@getflywheel/local-components';
 import useUpdateActiveSiteAndDataSources from '../useUpdateActiveSiteAndDataSources';
 import { store, useStoreSelector } from '../../store/store';
 import styles from './SiteInfoToolsSection.scss';
@@ -8,7 +8,8 @@ import { ToolsHeader } from './ToolsHeader';
 import { ToolsContent } from './ToolsContent';
 import { getEnabledProvidersHub } from '../../store/thunks';
 import TryAgain from './TryAgain';
-
+import { $offline } from '@getflywheel/local/renderer';
+import { useObserver } from 'mobx-react';
 interface Props {
 	site: Site;
 }
@@ -38,15 +39,21 @@ const SiteInfoToolsSection = ({ site }: Props) => {
 		);
 	}
 
-	return (
-		<div className={styles.SiteInfoToolsSection}>
-			<ToolsHeader site={site} />
-			<ToolsContent
-				className={styles.SiteInfoToolsSection_Content}
-				site={site}
-			/>
-		</div>
-	);
+	return useObserver(() => {
+		const offline = $offline.offline;
+
+		return (
+			<div className={styles.SiteInfoToolsSection}>
+				<OfflineBanner offline={offline} />
+				<ToolsHeader site={site} offline={offline} />
+				<ToolsContent
+					className={styles.SiteInfoToolsSection_Content}
+					offline={offline}
+					site={site}
+				/>
+			</div>
+		);
+	});
 };
 
 export default SiteInfoToolsSection;

--- a/src/renderer/components/siteinfotools/SiteInfoToolsSection.tsx
+++ b/src/renderer/components/siteinfotools/SiteInfoToolsSection.tsx
@@ -40,7 +40,7 @@ const SiteInfoToolsSection = ({ site }: Props) => {
 	}
 
 	return useObserver(() => {
-		const offline = $offline.offline;
+		const { offline } = $offline;
 
 		return (
 			<div className={styles.SiteInfoToolsSection}>

--- a/src/renderer/components/siteinfotools/SnapshotsTableList.scss
+++ b/src/renderer/components/siteinfotools/SnapshotsTableList.scss
@@ -96,6 +96,11 @@ $moreColWidth: 60px;
 	padding: 0;
 }
 
+.DropdownItemOffline {
+	font-weight: 300;
+	padding: 10px 15px !important;
+}
+
 .SnapshotsTableList_Empty_Header {
 	font-size: 1.4em;
 	margin-bottom: 20px;

--- a/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
+++ b/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 import styles from './SnapshotsTableList.scss';
+import classnames from 'classnames';
 import {
 	CircleWarnIcon,
 	DotsIcon,
@@ -181,7 +182,7 @@ const renderCellMoreMenu = (snapshot: BackupSnapshot, site: Site, provider: HubP
 		<FlyDropdown
 			caret={false}
 			className={styles.SnapshotsTableList_MoreDropdown}
-			classNameListItem={offline ? styles.DropdownItemOffline : ''}
+			classNameListItem={classnames({ [styles.DropdownItemOffline]: offline })}
 			items={items}
 			popperOptions={{ popperOffsetModifier: { offset: [15, 0] } }}
 		>

--- a/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
+++ b/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
@@ -185,6 +185,7 @@ const renderCellMoreMenu = (snapshot: BackupSnapshot, site: Site, provider: HubP
 			classNameListItem={classnames({ [styles.DropdownItemOffline]: offline })}
 			items={items}
 			popperOptions={{ popperOffsetModifier: { offset: [15, 0] } }}
+			useClickInsteadOfHover={!offline}
 		>
 			<DotsIcon/>
 		</FlyDropdown>

--- a/src/renderer/components/siteinfotools/StartBackupButton.tsx
+++ b/src/renderer/components/siteinfotools/StartBackupButton.tsx
@@ -9,11 +9,12 @@ import { BackupContents } from '../modals/BackupContents';
 import { selectSnapshotsForActiveSitePlusExtra } from '../../store/snapshotsSlice';
 
 interface Props {
+	offline: boolean,
 	site: Site;
 }
 
 export const StartBackupButton = (props: Props) => {
-	const { site } = props;
+	const { offline, site } = props;
 	const activeSiteProvider = useStoreSelector(selectors.selectActiveProvider);
 	const hasSnapshots = useStoreSelector(selectSnapshotsForActiveSitePlusExtra)?.length > 0;
 	const { backupIsRunning } = useStoreSelector((state) => state.director);
@@ -28,7 +29,7 @@ export const StartBackupButton = (props: Props) => {
 
 	const siteStatus = getSiteStatus(site);
 
-	let tooltipContent = <>Please start site to create a backup</>;
+	let tooltipContent = offline ? <>Check internet connection</> : <>Please start site to create a backup</>;
 
 	if (!activeSiteProvider) {
 		tooltipContent = <>Please select a provider for your backup</>;
@@ -38,7 +39,7 @@ export const StartBackupButton = (props: Props) => {
 		tooltipContent = <>Another backup or restore is already in progress</>;
 	}
 
-	const buttonDisabled = !activeSiteProvider || backupIsRunning || siteStatus !== 'running';
+	const buttonDisabled = offline || !activeSiteProvider || backupIsRunning || siteStatus !== 'running';
 
 	if (buttonDisabled) {
 		return (

--- a/src/renderer/components/siteinfotools/ToolsContent.tsx
+++ b/src/renderer/components/siteinfotools/ToolsContent.tsx
@@ -10,11 +10,12 @@ import { selectors } from '../../store/selectors';
 import { selectActivePagingDetails } from '../../store/snapshotsSlice';
 
 interface Props {
+	offline: boolean,
 	className: string;
 	site: Site;
 }
 
-export const ToolsContent = ({ className, site }: Props) => {
+export const ToolsContent = ({ className, site, offline }: Props) => {
 	const activeSite = useStoreSelector((state) => state.activeSite);
 	const activeSiteProvider = useStoreSelector(selectors.selectActiveProvider);
 	const activePagingDetails = useStoreSelector(selectActivePagingDetails);
@@ -37,7 +38,7 @@ export const ToolsContent = ({ className, site }: Props) => {
 				styles.ToolsContent,
 			)}
 		>
-			<SnapshotsTableList site={site}/>
+			<SnapshotsTableList site={site} offline={offline}/>
 		</div>
 	);
 };

--- a/src/renderer/components/siteinfotools/ToolsHeader.tsx
+++ b/src/renderer/components/siteinfotools/ToolsHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styles from './ToolsHeader.scss';
 import type { Site } from '@getflywheel/local';
 import { ProviderDropdown } from './ProviderDropdown';
-import { PrimaryButton } from '@getflywheel/local-components';
+import { PrimaryButton, Tooltip } from '@getflywheel/local-components';
 import { launchBrowserToHubBackups } from '../../helpers/launchBrowser';
 import { StartBackupButton } from './StartBackupButton';
 import { RefreshButton } from './RefreshButton';
@@ -12,11 +12,12 @@ import {
 } from '../../store/store';
 
 interface Props {
+	offline: boolean,
 	site: Site;
 }
 
 export const ToolsHeader = (props: Props) => {
-	const { site } = props;
+	const { offline, site } = props;
 	const { enabledProviders } = useStoreSelector((state) => state.providers);
 	const activeSiteProvider = useStoreSelector(selectors.selectActiveProvider);
 
@@ -27,22 +28,31 @@ export const ToolsHeader = (props: Props) => {
 				activeSiteProvider={activeSiteProvider}
 				multiMachineSelect={false}
 				siteId={site.id}
+				offline={offline}
 			/>
 			<div className={styles.ToolsHeaders_Right}>
-				<RefreshButton />
+				{!offline && <RefreshButton />}
 				{enabledProviders?.length
 					? (
-						<StartBackupButton site={site} />
+						<StartBackupButton site={site} offline={offline}/>
 					)
 					: (
-						<PrimaryButton
-							onClick={() => launchBrowserToHubBackups()}
-							privateOptions={{
-								padding: 'm',
-							}}
+						<Tooltip
+							content={<>Check internet connection</>}
+							popperOffsetModifier={{ offset: [-55, 10] }}
+							showDelay={300}
+							position="top-end"
 						>
-							Connect Provider
-						</PrimaryButton>
+							<PrimaryButton
+								disabled={offline}
+								onClick={() => launchBrowserToHubBackups()}
+								privateOptions={{
+									padding: 'm',
+								}}
+							>
+								Connect Provider
+							</PrimaryButton>
+						</Tooltip>
 					)
 				}
 			</div>


### PR DESCRIPTION
## Summary

**NOTE - This work will depend on api changes made in the next release of local (>6.1.2). Be sure to update `package.json` before publishing the update.**

Several "offline" behavior additions to cloud backups, including tooltips and disabling of buttons. The new offline banner component was also added. Leverages the newly exposed `$offline` store from the local-addon api. Now when a user is in cloud backups and loses internet: 
- The offline banner will be displayed
- The refresh button will be removed
- The provider dropdown text will turn grey 
- The provider dropdown menu will display the tooltip
- The back up or connect provider button will be disabled with a tooltip, and
- The individual backup dropdown menu (ellipses) will show the tooltip

Note that it was easiest to just modify the dropdown menus instead of disabling them and showing a tooltip on hover - those dropdowns already utilize the tooltip component, the only difference now being they will show on click instead of hover.

A separate ticket covers additional offline behavior for cloud backups, such as an interrupted/failed backup caused by loss of internet.

## Technical

Starting with `SiteInfoToolsSection.tsx`, prop-drilled `$offline.offline` down to relevant components and changed behavior accordingly. In most cases it was very simple, but disabling the "more menu" in `SnapshotsTableList.tsx ` required a change to the `VirtualTable` and `VirtualList` components in local-components in order to react to a change in the `extraData` prop.

NOTE - also updated the css for the provider dropdown menu to work as intended. It was using the wrong selector for the open caret SVG.

## Reference

- [LOC-2801](https://wpengine.atlassian.net/browse/LOC-2801)
