### PR TITLE
feat(LOC-2802): remove red offline banner from backups

### DIFF
--- a/src/renderer/components/siteinfotools/SiteInfoToolsSection.tsx
+++ b/src/renderer/components/siteinfotools/SiteInfoToolsSection.tsx
@@ -6,7 +6,7 @@ import { store, useStoreSelector } from '../../store/store';
 import styles from './SiteInfoToolsSection.scss';
 import { ToolsHeader } from './ToolsHeader';
 import { ToolsContent } from './ToolsContent';
-import { getEnabledProvidersHub } from '../../store/thunks';
+import { getEnabledProvidersHub, updateActiveSiteAndDataSources } from '../../store/thunks';
 import TryAgain from './TryAgain';
 import { $offline } from '@getflywheel/local/renderer';
 import { useObserver } from 'mobx-react';
@@ -16,6 +16,15 @@ interface Props {
 
 const SiteInfoToolsSection = ({ site }: Props) => (
 	useObserver(() => {
+		const { offline } = $offline;
+
+		// refresh when going from offline to online
+		React.useEffect(() => {
+			if (!offline) {
+				store.dispatch(updateActiveSiteAndDataSources({ siteId: site.id }));
+			}
+		}, [offline]);
+
 		// update active site anytime the site prop changes
 		useUpdateActiveSiteAndDataSources(site.id);
 
@@ -29,7 +38,7 @@ const SiteInfoToolsSection = ({ site }: Props) => (
 		 * we should handle that more gracefully
 		 */
 
-		if (hasErrorLoadingEnabledProviders) {
+		if (hasErrorLoadingEnabledProviders && !offline) {
 			return (
 				<div className={styles.SiteInfoToolsSection}>
 					<TryAgain
@@ -39,8 +48,6 @@ const SiteInfoToolsSection = ({ site }: Props) => (
 				</div>
 			);
 		}
-
-		const { offline } = $offline;
 
 		return (
 			<div className={styles.SiteInfoToolsSection}>

--- a/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
+++ b/src/renderer/components/siteinfotools/SnapshotsTableList.tsx
@@ -288,7 +288,9 @@ export const SnapshotsTableList = ({ site, offline }: Props) => {
 		return (
 			<div className={styles.SnapshotsTableList_EmptyCont}>
 				{activeSiteProvider
-					? <span>There are no Cloud Backups created on {activeSiteProvider.name} for this site yet.</span>
+					? offline
+						? <span>There was an issue retrieving your Cloud Backups from {activeSiteProvider.name}.</span>
+						: <span>There are no Cloud Backups created on {activeSiteProvider.name} for this site yet.</span>
 					: <div className={styles.SnapshotsTableList_Empty_GetStarted}>
 						<h1 className={styles.SnapshotsTableList_Empty_Header}>Getting started with Cloud Backups</h1>
 						<ul>

--- a/src/renderer/helpers/thunkUtils.ts
+++ b/src/renderer/helpers/thunkUtils.ts
@@ -49,7 +49,7 @@ const processAndCheckIfGlobalGraphQLError = (error: IpcAsyncResponse['error'], s
 			siteID: siteId,
 			variant: 'error',
 		});
-	} else if (error?.isHubGraphQLNetworkError) {
+	} else if (error?.isHubGraphQLNetworkError && navigator.onLine) {
 		showSiteBanner({
 			icon: 'warning',
 			id: GRAPHQL_COMMON_BANNER_ID,


### PR DESCRIPTION
This PR removes the red banner and error message shown when navigating to the cloud backups page when the user is offline (as determined by `navigator.onLine`). A hook was added that will also automatically refresh the cloud backups page when the user goes back online, as navigating to a site with backups while offline will show zero backups. 

Technical: Not sure if we ever get that `isHubGraphQLNetworkError` error when the user is online, but just in case, keeping it in there - maybe for if Hub is down? In that case, the red banner and error text would still be used.

An example site: 

<img width="350" alt="Screen Shot 2021-09-13 at 9 52 59 AM" src="https://user-images.githubusercontent.com/62191853/133108196-83579afd-9040-4bdc-a90f-a7afdf72b993.png">

Old behavior when navigating to the tools tab while offline: 

<img width="350" alt="Screen Shot 2021-09-13 at 9 53 31 AM" src="https://user-images.githubusercontent.com/62191853/133108261-e9954c0e-adae-4af4-a630-8fbf431ea757.png">
Note to remove this error after getting back online, the user has to manually refresh or leave and come back.
<br><br>
New behavior with new offline work: 

<img width="350" alt="Screen Shot 2021-09-13 at 9 56 07 AM" src="https://user-images.githubusercontent.com/62191853/133108471-f63d882b-5dbc-4b4e-848f-8d30a61e1ef6.png">
When connection is restore, will refresh to the first picture. 

