### PR TITLE
fix(LOC-3125): only add GoBack button on main add site page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@getflywheel/local-addon-backups",
   "productName": "Cloud Backups",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Local Team",
   "keywords": [
     "local-addon"

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -203,6 +203,10 @@ export default function (context): void {
 				LocalRenderer.sendIPCEvent('goToRoute', LOCAL_ROUTES.ADD_SITE_START);
 			};
 
+			const location = (document.querySelector('#root > div') as HTMLElement)?.dataset?.location;
+
+			if (location !== '/main/add-site/add') return null;
+
 			return (
 				<TextButton
 					className="GoBack"


### PR DESCRIPTION
This PR fixes the addition of the GoBack button from the Cloud Backups addon on every site creation screen. It should only appear on the main new site creation page, as the route it pushes brings you to that flow. 

The addon currently uses a hook called in a `NewSiteSite` component that is used in three places:
- Main Add Site flow
- Import site flow
- Pull site flow

This fix grabs the `#root` div element's first wrapper `div` child and ascertains the location based on the `data-location` attribute on that div. This solution seemed the most agnostic of Local's inner workings and the most accessible to add-on developers.