### PR TITLE
[NOJIRA] chore: fix backup list to work with upcoming Local Hub update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@getflywheel/local-addon-backups",
 	"productName": "Cloud Backups",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"author": "Local Team",
 	"keywords": [
 		"local-addon"

--- a/src/main/hubQueries.ts
+++ b/src/main/hubQueries.ts
@@ -305,7 +305,7 @@ export async function getBackupSnapshotsByRepo (repoId: number, limit: number, o
 					backup_repo_id: $backup_repo_id,
 					first: $first,
 					page: $page,
-					orderBy: [{ field: "updated_at", order: DESC }]
+					orderBy: [{ column: "updated_at", order: DESC }]
 				) {
 					data {
 						id


### PR DESCRIPTION
🚨 ‼️ **Ready to review, but wait until Local Hub has updated before merging this PR and re-releasing the add-on.** ‼️ 🚨 

## Background
We are working to update Local Hub to Laravel 9.

The update involves upgrading the “Lighthouse” GraphQL package for PHP, which includes a [breaking change to the GraphQL schema](https://github.com/nuwave/lighthouse/blob/master/UPGRADE.md#orderby-argument-renamed-to-column), affecting the Backups add-on.

## What's changed here?
This PR adjusts the GraphQL request to list backups so that it still works after Local Hub is upgraded.

## Important

When we upgrade Local Hub, users will see an error message instead of their list of backups until they upgrade this plugin to the upcoming version 2.0.2.

<img width="469" alt="Screenshot 2023-03-15 at 13 15 47" src="https://user-images.githubusercontent.com/647669/225882686-5daf784e-6e81-4f88-b1e5-f52757a47c0c.png">

## To test

1. Create a file at `/Users/[your-username]/Library/Application Support/Local/hub-api-settings.json` with this content:
    ```
    {"baseUrl": "https://hub-staging.localwp.com"}
    ```
2. In this branch, run `yarn && npm pack` to generate a backups add-on tarball from this PR.
3. In Local, install and activate the add-on, which should restart Local.
4. Log out of Local Hub if you're logged in, then log in again. The log in URL should start with `https://hub-staging.localwp.com/`.
5. In Local, create a site and one or more backups of that site.

You should see the list of backups in the Tools page:

<img width="1100" alt="Screenshot 2023-03-17 at 11 39 28" src="https://user-images.githubusercontent.com/647669/225882406-5d947777-8d21-44a5-babd-e408fe1fbe72.png">

## To revert testing state

1. In Local, log out of Local Hub.
2. Delete your `hub-api-settings.json` file.
3. Restart Local.