### PR TITLE
feat: move site to default group after creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	"devDependencies": {
 		"@babel/preset-react": "^7.12.13",
 		"@getflywheel/eslint-config-local": "^1.0.4",
-		"@getflywheel/local": ">=6.6.0",
+		"@getflywheel/local": ">=6.7.0",
 		"@types/classnames": "^2.2.11",
 		"@types/dateformat": "^3.0.1",
 		"@types/jest": "^26.0.15",
@@ -119,6 +119,6 @@
 		"xstate"
 	],
 	"engines": {
-		"local-by-flywheel": ">=6.5.2"
+		"local-by-flywheel": ">=6.7.0"
 	}
 }

--- a/src/main/services/cloneFromBackupService.ts
+++ b/src/main/services/cloneFromBackupService.ts
@@ -29,6 +29,7 @@ const {
 	siteData,
 	siteDatabase,
 	siteProvisioner,
+	sitesOrganization,
 } = serviceContainer;
 
 const logger = localLogger.child({
@@ -113,6 +114,8 @@ const setupDestinationSite = async (context: BackupMachineContext) => {
 	dupSite.path = path.join(localSitesDir, formattedSiteName);
 
 	siteData.addSite(dupSite.id, dupSite);
+
+	sitesOrganization.moveSitesToGroup([dupSite.id], 'default', true);
 
 	const destinationSite = getSiteDataFromDisk(dupSite.id);
 
@@ -279,7 +282,7 @@ const cloneMachine = Machine<BackupMachineContext, BackupMachineSchema>(
 					onError: onErrorFactory([deleteNewCloneSite]),
 				},
 			},
-			 [CloneFromBackupStates.setupDestinationSite]: {
+			[CloneFromBackupStates.setupDestinationSite]: {
 				invoke: {
 					src: (context) => setupDestinationSite(context),
 					onDone: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -630,10 +630,10 @@
     react-truncate-markup "^3.0.0"
     untildify "^4.0.0"
 
-"@getflywheel/local@>=6.6.0":
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/@getflywheel/local/-/local-6.6.0.tgz#bf8a3a17bb99b38fd85fdfa7e314af751672d320"
-  integrity sha512-+zpYz8irRpZrwEutho1ccnE083dw4E6UfXIZyBxNGVqd8xDJ7BuUB2M0/R5keUnHF1NGie5YVpVCnDk95FNMmA==
+"@getflywheel/local@>=6.7.0":
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/@getflywheel/local/-/local-6.7.0.tgz#30812569657c243db0e2cde901bad83017cc5714"
+  integrity sha512-QGF9BHk24s+3fjxb6xibtmGEn+BdU3+cyvhgTziSjFDVJZCz1ypZqNVQkVXMjRlPqshPDcROxCTjxdpaIHeCWw==
   dependencies:
     "@types/node" "^14.14.35"
     apollo-boost "^0.1.21"


### PR DESCRIPTION
This change moves the site into the default group after cloning from a cloud backup. I just added the SitesOrganizationService from the service container and called the appropriate function within the backups repo. This implementation mimics what we see in AddSiteService, Importer and CloneSiteService from core Local.

I also updated the version of Local that the backups repo pulls in so that I wouldn't see any red squiggles when trying to link and run this locally for testing.

In order to test you can clone the backups repo directly into your `/Users/first.last/Library/Application Support/Local/addons` directory. Switch to this branch and run yarn install followed by yarn build in local-addon-backups. Finally, enable the addon within Local and clone a site from a backup. You guys should have git lfs since it's required for core Local as well, but you may have to install it first if you run into issues with yarn install.

