### PR TITLE
fix(LOC-3249): fix Windows backup restore caused by nginx error.log file lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@getflywheel/local-addon-backups",
 	"productName": "Cloud Backups",
-	"version": "2.0.2",
+	"version": "2.1.0",
 	"author": "Local Team",
 	"keywords": [
 		"local-addon"

--- a/src/helpers/ignoreFilesPattern.ts
+++ b/src/helpers/ignoreFilesPattern.ts
@@ -4,7 +4,7 @@ import fs from 'fs-extra';
 import { formatHomePath } from '../helpers/formatHomePath';
 import type { Site } from '../types';
 
-export const excludePatterns = ['conf'];
+export const excludePatterns = ['conf', 'logs'];
 
 export const localBackupsIgnoreFileName = '.localbackupaddonignore.txt';
 

--- a/src/helpers/ignoreFilesPattern.ts
+++ b/src/helpers/ignoreFilesPattern.ts
@@ -9,8 +9,8 @@ export const excludePatterns = ['conf', 'logs'];
 export const localBackupsIgnoreFileName = '.localbackupaddonignore.txt';
 
 // Returns an array of directories within the site folder that we want to include in the backup
-// Filters out the 'conf' directory and any `.` files
-export const getFilteredSiteFiles = (site: Site) => {
+// Filters out excluded files
+export const getFilteredSiteFiles = (site: Pick<Site, 'path'>) => {
 	const sitePath = formatHomePath(site.path);
 
 	const filteredSiteFiles: string[] = [

--- a/src/main.ts
+++ b/src/main.ts
@@ -285,9 +285,6 @@ export default function (): void {
 				await siteDatabase.waitForDB(siteToSearchReplace);
 
 				await changeSiteDomain.changeSiteDomainToHost(siteToSearchReplace);
-
-				await siteProcessManager.restart(siteToSearchReplace);
-
 			}
 		},
 	);

--- a/src/main/services/cloneFromBackupService.ts
+++ b/src/main/services/cloneFromBackupService.ts
@@ -190,8 +190,6 @@ const searchReplace = async (context: BackupMachineContext) => {
 	await siteDatabase.waitForDB(siteToSearchReplace);
 
 	await changeSiteDomain.changeSiteDomainToHost(siteToSearchReplace);
-
-	await siteProcessManager.restart(siteToSearchReplace);
 };
 
 const moveSiteFromTmpDir = async (context: BackupMachineContext) => {

--- a/src/main/services/cloneFromBackupService.ts
+++ b/src/main/services/cloneFromBackupService.ts
@@ -24,7 +24,6 @@ const {
 	runSiteSQLCmd,
 	importSQLFile,
 	sendIPCEvent,
-	siteProcessManager,
 	changeSiteDomain,
 	siteData,
 	siteDatabase,

--- a/src/main/services/restoreService.ts
+++ b/src/main/services/restoreService.ts
@@ -315,6 +315,9 @@ export const restoreFromBackup = async (opts: {
 				// eslint-disable-next-line no-underscore-dangle
 				const error: ErrorState = JSON.parse(restoreService._state.context.error ?? null);
 
+				sendIPCEvent('updateSiteStatus', site.id, initialSiteStatus);
+				sendIPCEvent('refreshSiteVersions');
+
 				if (error) {
 					logger.error(JSON.stringify(error));
 					reject(error);

--- a/src/main/services/restoreService.ts
+++ b/src/main/services/restoreService.ts
@@ -129,15 +129,15 @@ const moveSiteFromTmpDir = async (context: BackupMachineContext) => {
 
 	await Promise.all(promises);
 
-	fs.copySync(
-		tmpDirData.name,
-		sitePath,
-		/**
-		 * @todo ensure that we don't go willy nilly deleting files that are actually symlinks pointing outside of a site directory
-		 */
-	);
+	const filesToCopy = getFilteredSiteFiles({ path: tmpDirData.name });
 
-	logger.info(`Site contents moved from \'${tmpDirData.name}\' to \'${sitePath}\'`);
+	for (const file of filesToCopy) {
+		const relativePath = path.relative(tmpDirData.name, file);
+		const dest = path.join(sitePath, relativePath);
+		fs.copySync(file, dest);
+		logger.info(`Copied \'${file}\' to \'${dest}\'`);
+		/** @todo ensure that we don't go willy nilly deleting files that are actually symlinks pointing outside of a site directory */
+	}
 };
 
 const restoreBackup = async (context: BackupMachineContext) => {

--- a/src/main/services/restoreService.ts
+++ b/src/main/services/restoreService.ts
@@ -125,8 +125,6 @@ const moveSiteFromTmpDir = async (context: BackupMachineContext) => {
 
 	logger.info(`removing the following directories/files to prepare for the site backup: ${itemsToDelete.map((file) => `"${file}"`).join(', ')}`);
 
-	await siteProcessManager.stop(site, { dumpDatabase: false, updateStatus: false });
-
 	const promises = itemsToDelete.map((dirOrFile: string) => fs.remove(dirOrFile));
 
 	await Promise.all(promises);
@@ -138,8 +136,6 @@ const moveSiteFromTmpDir = async (context: BackupMachineContext) => {
 		 * @todo ensure that we don't go willy nilly deleting files that are actually symlinks pointing outside of a site directory
 		 */
 	);
-
-	await siteProcessManager.start(site, false, false);
 
 	logger.info(`Site contents moved from \'${tmpDirData.name}\' to \'${sitePath}\'`);
 };


### PR DESCRIPTION
Windows was locking the nginx `error.log` file because it's being used by a running site's nginx process. We were going in and deleting the `app` and `logs` directories (essentially anything other than `conf`) prior to moving the backup from the tmp dir, which was causing the backup restore to break on Windows. This PR adds the `logs` directory to the list of excluded folders for files included in a backup, so we don't try to delete it anymore. It also takes the same patterns and only copies those files from the tmp directory to cover old backups. 

I also removed some site restarts that weren't actually necessary and were just increasing the time a cloud backup restore/clone was taking.

## To test:

To test this PR, you can pull down the code and either:

- Pack up and install from disk. Run `yarn install`, `yarn build`, and `npm pack`, then you should get a `tar.gz` in the root of the repo. In Local, you can navigate to the Add-ons marketplace (puzzle piece), click the "Installed" tab, and choose `Install from disk`. Select the tarball you created and wait a bit for it to install. 

> Packing it up on MacOS and then installing from disk on Parallels is probably the easiest route for testing on windows here, especially if you don't have the dev environment fully set up on Windows. You can even just use the latest Local application, not even a dev environment. 

- Link up the add-on for Local development. Pull down the code, run `yarn install` and `yarn build`, and then create a symlink to the Addons directory in Application Support. Then open Local and enable the add-on. I have an alias that I run from the root of the add-on repo that looks like this:

```bash
alias linkAddon='ln -s $(pwd) ~/Library/Application\ Support/Local/addons/$(basename $(pwd))'
```

Once this version of the addon is installed, you'll need to log into your Local account, hook up a Google Drive or Dropbox account (I think our `@wpengine.com` emails don't allow this, so watch out if you have that google account hooked up in any way, even for SSO). Then you can create a backup of a site via the `Tools > Cloud Backups` tab. 

> Note - I only tested this by creating a backup on MacOS and restoring it on Windows

Then create a new site from a backup on Windows, and it should work!

## Reference

- [LOC-3249](https://wpengine.atlassian.net/browse/LOC-3249)


[LOC-3249]: https://wpengine.atlassian.net/browse/LOC-3249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ