### PR TITLE
fix(LOC-2973): update site domain and path when name is set

### DIFF
--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.scss
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.scss
@@ -10,7 +10,7 @@
 	align-items: left;
 	width: 50%;
 	min-width: 590px;
-	padding: 0 0 50px;
+	padding: 0 0 35px;
 }
 
 .headerPadding {
@@ -19,19 +19,6 @@
 
 .tooltip {
 	position: absolute;
-	bottom: 30px;
-	right: 30px;
-}
-
-.errorText {
-	color: $red;
-	font-weight: 500;
-}
-
-.errorTextContainer {
-	margin-top: 10px;
-}
-
-.errorState {
-	box-shadow: inset 0 0 0 2px $red !important;
+	bottom: 20px;
+	right: 20px;
 }

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
@@ -43,26 +43,27 @@ export const SelectSiteBackup = (props: Props) => {
 	});
 
 	const generateSiteSettingsData = useCallback(() => {
-		const { multiMachineRestore } = store.getState();
-		const formattedSiteName = formatSiteNicename(multiMachineRestore.newSiteName);
-		const formattedSiteDomain = `${formattedSiteName}${defaultLocalSettings['new-site-defaults'].tld}`;
+		const { newSiteName: siteName } = store.getState().multiMachineRestore;
+		const formattedSiteName = formatSiteNicename(siteName);
 
-		const sitePath = path.join(defaultLocalSettings['new-site-defaults'].sitesPath, formattedSiteName);
+		const siteDomain = `${formattedSiteName}${defaultLocalSettings['new-site-defaults'].tld}`;
 
-		const formattedSitePath = osPath.addOSTrailingSlash(osPath.toNative(sitePath));
+		const unformattedSitePath = path.join(defaultLocalSettings['new-site-defaults'].sitesPath, formattedSiteName);
+		const sitePath = osPath.addOSTrailingSlash(osPath.toNative(unformattedSitePath));
 
 		return {
-			formattedSiteName,
-			formattedSiteDomain,
-			formattedSitePath,
-			siteName: multiMachineRestore.newSiteName,
+			siteName,
+			siteDomain,
+			sitePath,
 		};
 	}, [defaultLocalSettings]);
 
 	useEffect(() => {
+		const newSiteSettings = generateSiteSettingsData();
+
 		updateSiteSettings({
 			...siteSettings,
-			siteName: newSiteName,
+			...newSiteSettings,
 		});
 
 		const checkSiteName = async () => {
@@ -92,9 +93,7 @@ export const SelectSiteBackup = (props: Props) => {
 		// used to build out the new site object
 		updateSiteSettings({
 			...siteSettings,
-			siteName: newSiteSettings.siteName,
-			siteDomain: newSiteSettings.formattedSiteDomain,
-			sitePath: newSiteSettings.formattedSitePath,
+			...newSiteSettings,
 			cloudBackupMeta: {
 				createdFromCloudBackup: true,
 				repoID: siteUUID,

--- a/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
+++ b/src/renderer/components/multimachinebackups/SelectSiteBackup.tsx
@@ -1,6 +1,5 @@
-import { FlySelect, PrimaryButton, ProgressBar, Text, TextButton, Title, Tooltip } from '@getflywheel/local-components';
+import { FlySelect, BasicInput, PrimaryButton, ProgressBar, Text, TextButton, Title, Tooltip } from '@getflywheel/local-components';
 import * as LocalRenderer from '@getflywheel/local/renderer';
-import classNames from 'classnames';
 import path from 'path';
 import React, { useCallback, useEffect, useState } from 'react';
 import { IPCASYNC_EVENTS, LOCAL_ROUTES } from '../../../constants';
@@ -150,20 +149,16 @@ export const SelectSiteBackup = (props: Props) => {
 					<div className="FormRow __MarginTop_20 __MarginBottom_0">
 						<div className="FormField">
 							<label>Give the site a new unique name</label>
-							<input
-								className={classNames('TID_NewSiteSite_Input_SiteName_Small', {
-									[styles.errorState]: isDuplicateName,
-								})}
-								type="text"
+							<BasicInput
+								style={{ height: 85 }}
+								className="TID_NewSiteSite_Input_SiteName_Small"
 								disabled={selectedSite === null}
 								value={newSiteName}
 								onChange={(e) => store.dispatch(actions.setNewSiteName(e.target.value))}
+								invalid={isDuplicateName}
+								invalidMessage='Please give the site a unique name'
+
 							/>
-							{isDuplicateName && (
-								<div className={styles.errorTextContainer}>
-									<Text className={styles.errorText}>Please give the site a unique name</Text>
-								</div>
-							)}
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## Bug fix

We require a unique name and allowed the users to name the new site when creating from a backup. However, we weren't updating the site domain or the path, causing things to fail. This commit updates those values when the name changes.

## Style tweaks and BasicInput

BasicInput has built-in invalid/error states and messages.

Also adds a fixed height to stop things from shifting when a site name is invalid.

Finally, tweaks the continue buttons padding so it doesn't shift when enabled.

## To test:

To test this PR, you can pull down the code and either:

- Run `yarn install`, `yarn build`, and `npm pack`, then you should get a `tar.gz` in the root of the repo. In Local, you can navigate to the Add-ons marketplace (puzzle piece), click the "Installed" tab, and choose `Install from disk`. Select the tarball you created and wait a bit for it to install.
- Link up the add-on for Local development. Pull down the code, run `yarn install` and `yarn build`, and then create a symlink to the Addons directory in Application Support. Then open Local and enable the add-on. I have an alias that I run from the root of the add-on repo that looks like this:

```bash
alias linkAddon='ln -s $(pwd) ~/Library/Application\ Support/Local/addons/$(basename $(pwd))'
```

Once this version of the addon is installed, you'll need to log into your Local account, hook up a Google Drive or Dropbox account (I think our `@wpengine.com` emails don't allow this, so watch out if you have that google account hooked up in any way, even for SSO). Then you can create a backup of a site via the `Tools > Cloud Backups` tab.

Then create a new site from the backup, defaults all the way. Then, create another site from the same backup - you should see a screen that prompts you for a unique site name. Enter a new name, then continue on. Before this fix, the site creation would hang on provisioning, but now it should work, with the site path, site name, and site domain all containing the new name.

## Reference

- [LOC-2973](https://wpengine.atlassian.net/browse/LOC-2973)


[LOC-2973]: https://wpengine.atlassian.net/browse/LOC-2973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ