### PR TITLE
feature: expose restore failure reasons

### DIFF
--- a/src/main/services/restoreService.ts
+++ b/src/main/services/restoreService.ts
@@ -294,12 +294,18 @@ export const restoreFromBackup = async (opts: {
 	snapshotID: string;
 	repoID?: string;
 }): Promise<null | ErrorState> => {
+	const { site, provider, snapshotID, repoID } = opts;
+
 	if (serviceState.inProgressStateMachine) {
 		logger.warn('Restore process aborted: only one backup or restore process is allowed at one time and a backup or restore is already in progress.');
 		return Promise.reject('Restore process aborted: only one backup or restore process is allowed at one time and a backup or restore is already in progress.');
 	}
 
-	const { site, provider, snapshotID, repoID } = opts;
+	if (siteProcessManager.getSiteStatus(site) !== 'running') {
+		logger.info('Restore process aborted: site is not running.');
+		return Promise.reject('Please start the site before restoring a backup.');
+	}
+
 	return new Promise((resolve, reject) => {
 		const initialSiteStatus = siteProcessManager.getSiteStatus(site);
 

--- a/src/renderer/store/thunks.ts
+++ b/src/renderer/store/thunks.ts
@@ -207,12 +207,12 @@ const restoreSite = createAsyncThunk<
 			],
 			siteId,
 			rejectWithValue,
-			(details) => {
+			(details, response) => {
 				if (details.isErrorAndUncaptured) {
 					showSiteBanner({
 						icon: 'warning',
 						id: details.bannerId,
-						message: `There was an error while restoring your backup.`,
+						message: response?.error?.message || 'There was an error while restoring your backup.',
 						siteID: details.siteId,
 						title: 'Cloud Backup restore failed!',
 						variant: 'error',


### PR DESCRIPTION
• **Exposes the reason for a restore failure** when available instead of using a generic error. This should help users and support, even if the messages may be more technical when presenting uncaught JS errors.
• **Prompts users to start a site** if they attempt to restore before starting. We could still improve this by (a) starting a site automatically during restore or (b) ghosting "restore" options if a site isn't started (like we do [if another backup is running](https://github.com/getflywheel/local-addon-backups/blob/5b299bdc6e98f8fd6247eea3a30c205024a130f2/src/renderer/components/siteinfotools/SnapshotsTableList.tsx#L135)), but communicating the failure reason is still an improvement that might reduce [confusion we have seen around the generic error](https://community.localwp.com/t/unable-to-restore-cloud-backup-but-i-am-able-to-clone-site-from-backup/40448).

## Screenshots

| Before | After |
| - | - |
| <img width="1312" alt="failure-before" src="https://github.com/getflywheel/local-addon-backups/assets/647669/051524c5-d4e8-454b-a4bc-137eb29548c9"> | <img width="1312" alt="failure-after" src="https://github.com/getflywheel/local-addon-backups/assets/647669/482f069f-b5e7-406b-8331-43a484b161ea"> |

## To test

1. `yarn && yarn build && npm pack` 
2. Install the built add-on.
3. Attempt a restore from a backup for a fresh site that is not running (Google Drive or Dropbox). You should see the message.
4. Attempt a restore when the site is running. It should restore without error.