### PR TITLE
Remove `@electron/remote`, use IPC instead of electron.shell for "edit files to ignore" button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@getflywheel/local-addon-backups",
 	"productName": "Cloud Backups",
-	"version": "2.1.1",
+	"version": "2.1.2",
 	"author": "Local Team",
 	"keywords": [
 		"local-addon"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
 	},
 	"dependencies": {
 		"@apollo/client": "^3.8.5",
-		"@electron/remote": "2.1.2",
 		"@getflywheel/local-components": "^17.6.6",
 		"@reduxjs/toolkit": "^1.9.3",
 		"classnames": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 	},
 	"dependencies": {
 		"@apollo/client": "^3.8.5",
-		"@electron/remote": "^1.1.0",
+		"@electron/remote": "2.1.2",
 		"@getflywheel/local-components": "^17.6.6",
 		"@reduxjs/toolkit": "^1.9.3",
 		"classnames": "^2.2.6",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,7 @@ export const IPCASYNC_EVENTS = {
 	MULTI_MACHINE_GET_AVAILABLE_PROVIDERS: 'backups:get-enabled-providers-multi-machine',
 	SHOULD_LOAD_PROMO_BANNER: 'backups:should-load-promo-banner',
 	REMOVE_PROMO_BANNER: 'backups:remove-promo-banner',
+	OPEN_FILE_AT_PATH: 'backups:open-file-at-path',
 };
 
 export const MULTI_MACHINE_BACKUP_ERRORS = {

--- a/src/helpers/ignoreFilesPattern.ts
+++ b/src/helpers/ignoreFilesPattern.ts
@@ -23,7 +23,7 @@ export const getFilteredSiteFiles = (site: Pick<Site, 'path'>) => {
 
 // returns the path to the site specific ignore file for the site backup
 // handles copying the default ignore file into the site prior to site backup
-export const getIgnoreFilePath = async (site: Site) => {
+export const getIgnoreFilePath = (site: Site) => {
 	let defaultIgnoreFilePath = path.join(__dirname, '..', 'resources', 'default-ignore-file');
 
 	if (!fs.existsSync(defaultIgnoreFilePath)) {
@@ -38,7 +38,7 @@ export const getIgnoreFilePath = async (site: Site) => {
 	const ignoreFilePath = path.join(expandedSitePath, localBackupsIgnoreFileName);
 
 	if (fs.existsSync(formerIgnoreFilePath)) {
-		await fs.rename(formerIgnoreFilePath, ignoreFilePath);
+		fs.renameSync(formerIgnoreFilePath, ignoreFilePath);
 	}
 
 	if (!fs.existsSync(ignoreFilePath)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,6 @@ const {
 	localLogger,
 	changeSiteDomain,
 	siteDatabase,
-	siteProcessManager,
 } = serviceContainer;
 
 const logger = localLogger.child({

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import { IPCASYNC_EVENTS, SHOW_CLOUD_BACKUPS_PROMO_BANNER } from './constants';
 import { createIpcAsyncError, createIpcAsyncResult } from './helpers/createIpcAsyncResponse';
 import { getServiceContainer } from '@getflywheel/local/main';
 import { checkForDuplicateSiteName } from './helpers/checkForDuplicateSiteName';
+import { shell } from 'electron';
 
 const serviceContainer = getServiceContainer().cradle;
 const {
@@ -241,6 +242,10 @@ export default function (): void {
 		{
 			channel: IPCASYNC_EVENTS.REMOVE_PROMO_BANNER,
 			callback: async () => await LocalMain.UserData.remove(SHOW_CLOUD_BACKUPS_PROMO_BANNER),
+		},
+		{
+			channel: IPCASYNC_EVENTS.OPEN_FILE_AT_PATH,
+			callback: async (path: string) => await shell.openPath(path),
 		},
 	];
 

--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -211,14 +211,8 @@ export async function initRepo ({ provider, encryptionPassword, localBackupRepoI
 	}
 }
 
-/**
- * Creates a new restic snapshot on a given provider
- *
- * @param site
- * @param provider
- * @param encryptionPassword
- */
-export async function createSnapshot (site: Site, provider: Providers, encryptionPassword: string) {
+/** Creates a new restic snapshot on a given provider */
+export function createSnapshot (site: Site, provider: Providers, encryptionPassword: string) {
 	const { localBackupRepoID } = getSiteDataFromDisk(site.id);
 
 	if (!localBackupRepoID) {

--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -217,21 +217,18 @@ export async function initRepo ({ provider, encryptionPassword, localBackupRepoI
  * @param site
  * @param provider
  * @param encryptionPassword
- * @returns
  */
-export async function createSnapshot (site: Site, provider: Providers, encryptionPassword: string): Promise<string> {
+export async function createSnapshot (site: Site, provider: Providers, encryptionPassword: string) {
 	const { localBackupRepoID } = getSiteDataFromDisk(site.id);
 
 	if (!localBackupRepoID) {
 		throw new Error(`No backup repo id found for ${site.name}`);
 	}
 
-	const ignoreFilePath = await getIgnoreFilePath(site);
-
 	const flags = [
 		'--json',
 		`--exclude "${excludePatterns.join(' ')}"`,
-		`--exclude-file "${ignoreFilePath}"`,
+		`--exclude-file "${getIgnoreFilePath(site)}"`,
 	];
 
 	/**

--- a/src/renderer/components/modals/BackupContents.tsx
+++ b/src/renderer/components/modals/BackupContents.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import {
-	CopyButton,
 	FlyModal,
 	Title,
 	PrimaryButton,
@@ -12,7 +11,8 @@ import type { Site } from '@getflywheel/local';
 import styles from './BackupContents.scss';
 import { fetchSiteSizeInMB } from './fetchSiteSizeInMB';
 import { getIgnoreFilePath } from '../../../helpers/ignoreFilesPattern';
-import { INPUT_MAX } from '../../../constants';
+import { IPCASYNC_EVENTS, INPUT_MAX } from '../../../constants';
+import { ipcAsync } from '@getflywheel/local/renderer';
 
 export interface ModalContentsProps {
 	submitAction: (description) => void;
@@ -22,7 +22,6 @@ export interface ModalContentsProps {
 
 export const BackupContents = (props: ModalContentsProps) => {
 	const { submitAction, site, hasSnapshots } = props;
-	const ignoreFilePath = getIgnoreFilePath(site);
 
 	const [siteSizeInMB, setSiteSizeInMB] = useState(0);
 	const [inputDescriptionData, setInputData] = useState('');
@@ -40,6 +39,10 @@ export const BackupContents = (props: ModalContentsProps) => {
 	const onModalSubmit = () => {
 		submitAction(inputDescriptionData);
 		FlyModal.onRequestClose();
+	};
+
+	const onClickEditIgnore = (site: Site) => {
+		ipcAsync(IPCASYNC_EVENTS.OPEN_FILE_AT_PATH, getIgnoreFilePath(site));
 	};
 
 	return (
@@ -72,8 +75,13 @@ export const BackupContents = (props: ModalContentsProps) => {
 
 				<Title size="m" style={{ paddingTop: 15 }}>Ignore files</Title>
 				<p style={{ marginTop: 7 }}>Add any files(s) here that you'd like to exclude from this backup:</p>
-				<code>{ignoreFilePath}</code>
-				<CopyButton style={{ marginTop: 10 }} textToCopy={ignoreFilePath} />
+				<TextButton
+					style={{ marginTop: 5 }}
+					className={styles.NoPaddingLeft}
+					onClick={() => onClickEditIgnore(site)}
+				>
+					Edit files to ignore
+				</TextButton>
 			</div>
 			<hr />
 

--- a/src/renderer/components/modals/BackupContents.tsx
+++ b/src/renderer/components/modals/BackupContents.tsx
@@ -47,11 +47,6 @@ export const BackupContents = (props: ModalContentsProps) => {
 		FlyModal.onRequestClose();
 	};
 
-	const onClickEditIgnore = async (site: Site) => {
-		const ignoreFilePath = await getIgnoreFilePath(site);
-		shell.openPath(ignoreFilePath);
-	};
-
 	return (
 		<div>
 			<Title size="l" container={{ margin: 'm 0' }}>Back up site</Title>
@@ -81,15 +76,8 @@ export const BackupContents = (props: ModalContentsProps) => {
 				/>
 
 				<Title size="m" style={{ paddingTop: 15 }}>Ignore files</Title>
-				<p style={{ marginTop: 7 }}>Add any files(s) you would like to exclude from this backup.</p>
-
-				<TextButton
-					style={{ marginTop: 5 }}
-					className={styles.NoPaddingLeft}
-					onClick={() => onClickEditIgnore(site)}
-				>
-					Edit files to ignore
-				</TextButton>
+				<p style={{ marginTop: 7 }}>Add any files(s) you would like to exclude from this backup:</p>
+				<p>{getIgnoreFilePath(site)}</p>
 			</div>
 			<hr />
 

--- a/src/renderer/components/modals/BackupContents.tsx
+++ b/src/renderer/components/modals/BackupContents.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import {
+	CopyButton,
 	FlyModal,
 	Title,
 	PrimaryButton,
@@ -13,10 +14,6 @@ import { fetchSiteSizeInMB } from './fetchSiteSizeInMB';
 import { getIgnoreFilePath } from '../../../helpers/ignoreFilesPattern';
 import { INPUT_MAX } from '../../../constants';
 
-const remote = require('@electron/remote');
-
-const { shell } = remote;
-
 export interface ModalContentsProps {
 	submitAction: (description) => void;
 	site: Site;
@@ -25,17 +22,15 @@ export interface ModalContentsProps {
 
 export const BackupContents = (props: ModalContentsProps) => {
 	const { submitAction, site, hasSnapshots } = props;
+	const ignoreFilePath = getIgnoreFilePath(site);
 
 	const [siteSizeInMB, setSiteSizeInMB] = useState(0);
 	const [inputDescriptionData, setInputData] = useState('');
 
 	useEffect(() => {
-		const setDiskSize = async () => {
-			const siteSize = await fetchSiteSizeInMB(site);
-			setSiteSizeInMB(siteSize);
-		};
-
-		setDiskSize();
+		fetchSiteSizeInMB(site).then(
+			(siteSize) => setSiteSizeInMB(siteSize),
+		);
 	}, []);
 
 	const onInputChange = (event) => {
@@ -76,8 +71,9 @@ export const BackupContents = (props: ModalContentsProps) => {
 				/>
 
 				<Title size="m" style={{ paddingTop: 15 }}>Ignore files</Title>
-				<p style={{ marginTop: 7 }}>Add any files(s) you would like to exclude from this backup:</p>
-				<p>{getIgnoreFilePath(site)}</p>
+				<p style={{ marginTop: 7 }}>Add any files(s) here that you'd like to exclude from this backup:</p>
+				<code>{ignoreFilePath}</code>
+				<CopyButton style={{ marginTop: 10 }} textToCopy={ignoreFilePath} />
 			</div>
 			<hr />
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1352,10 +1352,10 @@
   optionalDependencies:
     global-agent "^3.0.0"
 
-"@electron/remote@^1.1.0":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@electron/remote/-/remote-1.2.2.tgz#4c390a2e669df47af973c09eec106162a296c323"
-  integrity sha512-PfnXpQGWh4vpX866NNucJRnNOzDRZcsLcLaT32fUth9k0hccsohfxprqEDYLzRg+ZK2xRrtyUN5wYYoHimMCJg==
+"@electron/remote@2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@electron/remote/-/remote-2.1.2.tgz#52a97c8faa5b769155b649ef262f2f8c851776e6"
+  integrity sha512-EPwNx+nhdrTBxyCqXt/pftoQg/ybtWDW3DUWHafejvnB1ZGGfMpv6e15D8KeempocjXe78T7WreyGGb3mlZxdA==
 
 "@electron/remote@^2.0.8":
   version "2.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1352,11 +1352,6 @@
   optionalDependencies:
     global-agent "^3.0.0"
 
-"@electron/remote@2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@electron/remote/-/remote-2.1.2.tgz#52a97c8faa5b769155b649ef262f2f8c851776e6"
-  integrity sha512-EPwNx+nhdrTBxyCqXt/pftoQg/ybtWDW3DUWHafejvnB1ZGGfMpv6e15D8KeempocjXe78T7WreyGGb3mlZxdA==
-
 "@electron/remote@^2.0.8":
   version "2.0.9"
   resolved "https://registry.yarnpkg.com/@electron/remote/-/remote-2.0.9.tgz#092ff085407bc907f45b89a72c36faa773ccf2d9"


### PR DESCRIPTION
<strike>Tyson's input on this PR would help.</strike> [Nick says: input [gathered in Slack](https://wpengine.slack.com/archives/C06J67S6NF6/p1708522847016129), we've reinstated the "edit files to ignore" button for now.]

* Fixes [Backups add-on fails to load](https://github.com/getflywheel/flywheel-local/pull/1937#issuecomment-1946649159) that Nick found (`Error Loading Add-on: user/Application Support/Local/addons/@getflywheel-local-addon-backups/lib/renderer.js TypeError: features.isDesktopCapturerEnabled is not a function`)
* [Nick added]: Opens the backups ignore file using IPC instead of `electron-remote.shell` or `electron.shell`.
* Remove `@electron/remote` 
* [@electron/remove](https://www.npmjs.com/package/@electron/remote) recommends that you don't use it:

>⚠️ Warning! This module has [many subtle pitfalls](https://medium.com/@nornagon/electrons-remote-module-considered-harmful-70d69500f31). There is almost always a better way to accomplish your task than using this module. For example, [ipcRenderer.invoke](https://www.electronjs.org/docs/latest/api/ipc-renderer#ipcrendererinvokechannel-args) can serve many common use cases.

>@electron/remote is a replacement for the built-in remote module in Electron, which is deprecated and will eventually be removed.

## Testing steps

1. Select a site
2. Select 'Tools'
3. Select 'Cloud Backups'.
4. Click 'Back up site'.
5. Check that the "edit files to ignore" button opens the ignore file.

<img width="1115" alt="Screenshot 2024-02-16 at 4 32 51 PM" src="https://github.com/getflywheel/local-addon-backups/assets/4063887/21ffc231-7fea-4b07-9633-be4ccc55c4ab">

