### PR TITLE
chore: bump @getflywheel/local to v.9.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	"devDependencies": {
 		"@babel/preset-react": "^7.26.3",
 		"@getflywheel/eslint-config-local": "^1.0.4",
-		"@getflywheel/local": "^9.2.2",
+		"@getflywheel/local": "^9.2.4",
 		"@svgr/webpack": "^8.1.0",
 		"@types/classnames": "^2.3.4",
 		"@types/dateformat": "^5.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,16 +1131,16 @@
     react-truncate-markup "^3.0.0"
     untildify "^4.0.0"
 
-"@getflywheel/local@^9.2.2":
-  version "9.2.2"
-  resolved "https://registry.yarnpkg.com/@getflywheel/local/-/local-9.2.2.tgz#03595e823189de7d70d8f5c743f3be7dc94a7a9a"
-  integrity sha512-8GB3unh4qd2WxQbN7e01NLloU52HzU5xvrOl8biw09iPu9qsw34A6rs87xhA0OrtGEDnIoA34nU7dK7w+xJkQA==
+"@getflywheel/local@^9.2.4":
+  version "9.2.5"
+  resolved "https://registry.yarnpkg.com/@getflywheel/local/-/local-9.2.5.tgz#a2bb78f64dd1badbdcf55cf6f2696e875cd547b4"
+  integrity sha512-ps7KxV6J7Wz3lRSqW+McGS/l+AgpAmYigCGpgyDgE+P31fwrmBJEDzySMW6FTAtApKJVO+YeR+uzUS+txSv3pg==
   dependencies:
-    "@types/node" "^18.18.0"
+    "@types/node" "^22.14.0"
     apollo-boost "^0.1.21"
     awilix "^4.2.5"
     cross-fetch "^3.1.5"
-    electron "28.2.2"
+    electron "^v35"
     graphql "^15.4.0"
     graphql-subscriptions "^1.1.0"
     graphql-tag "^2.11.0"
@@ -1860,12 +1860,12 @@
   dependencies:
     undici-types "~6.21.0"
 
-"@types/node@^18.11.18", "@types/node@^18.18.0":
-  version "18.19.86"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.86.tgz#a7e1785289c343155578b9d84a0e3e924deb948b"
-  integrity sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==
+"@types/node@^22.14.0", "@types/node@^22.7.7":
+  version "22.16.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.16.4.tgz#00c763ad4d4e45f62d5a270c040ae1a799c7e38a"
+  integrity sha512-PYRhNtZdm2wH/NT2k/oAJ6/f2VD2N2Dag0lGlx2vWgMSJXGNmlce5MiTQzoWAiIJtso30mjnfQCOKVH+kAQC/g==
   dependencies:
-    undici-types "~5.26.4"
+    undici-types "~6.21.0"
 
 "@types/react-dom@^19.0.4":
   version "19.1.1"
@@ -3293,13 +3293,13 @@ electron-to-chromium@^1.5.73:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.130.tgz#19f5dd2cf166a8dd1350b08230a33faba0d8f4ec"
   integrity sha512-Ou2u7L9j2XLZbhqzyX0jWDj6gA8D3jIfVzt4rikLf3cGBa0VdReuFimBKS9tQJA4+XpeCxj1NoWlfBXzbMa9IA==
 
-electron@28.2.2:
-  version "28.2.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-28.2.2.tgz#d5aa4a33c00927d83ca893f8726f7c62aad98c41"
-  integrity sha512-8UcvIGFcjplHdjPFNAHVFg5bS0atDyT3Zx21WwuE4iLfxcAMsyMEOgrQX3im5LibA8srwsUZs7Cx0JAUfcQRpw==
+electron@^v35:
+  version "35.7.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-35.7.2.tgz#82a254fe0dde937963cd122127dc16bac224dd82"
+  integrity sha512-MfAgKOs8OQJFEixUNRvuAzQQa0CciX9618JK6n7+U4aaHGS0PExoeL7bOwrI4L1rG3tH2gwcihI6tkxsSXX0iA==
   dependencies:
     "@electron/get" "^2.0.0"
-    "@types/node" "^18.11.18"
+    "@types/node" "^22.7.7"
     extract-zip "^2.0.1"
 
 emittery@^0.13.1:
@@ -7177,11 +7177,6 @@ unbox-primitive@^1.1.0:
     has-bigints "^1.0.2"
     has-symbols "^1.1.0"
     which-boxed-primitive "^1.1.1"
-
-undici-types@~5.26.4:
-  version "5.26.5"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
-  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 undici-types@~6.21.0:
   version "6.21.0"


### PR DESCRIPTION
## Summary 

The Dependabot alerts [Electron vulnerable to Heap Buffer Overflow in NativeImage](https://github.com/advisories/GHSA-6r2x-8pq8-9489) . The resolution on the dependabot was to bump `@getflywheel/local` to latest version which is `v9.2.4` which electron was currently on version `v35` already met the minimum patch requirement.