### PR TITLE
[LOC-6792] chore: bump version to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@getflywheel/local-addon-backups",
 	"productName": "Cloud Backups",
-	"version": "2.1.3",
+	"version": "2.2.0",
 	"author": "Local Team",
 	"keywords": [
 		"local-addon"


### PR DESCRIPTION
This release includes the backup migration process for Local 10.

It won't be released until the new version of Local is out.